### PR TITLE
add: transaction reciept to enable tracking of gas spend of transactions.

### DIFF
--- a/rubi/docs/examples/example.py
+++ b/rubi/docs/examples/example.py
@@ -51,11 +51,13 @@ limit_order = NewLimitOrder(
     price=Decimal("1914.13")
 )
 
-client.place_limit_order(
+transaction_result = client.place_limit_order(
     transaction=Transaction(
         orders=[limit_order]
     )
 )
+
+log.info(transaction_result)
 
 # Print events and order books
 while True:

--- a/rubi/rubi/client.py
+++ b/rubi/rubi/client.py
@@ -12,6 +12,7 @@ from rubi.contracts import (
     RubiconMarket,
     RubiconRouter,
     ERC20,
+    TransactionReceipt
 )
 from rubi.network import (
     Network,
@@ -64,7 +65,6 @@ class Client:
         self.router = RubiconRouter.from_network(network=self.network, wallet=self.wallet, key=self.key)
 
         self._pairs: Dict[str, Pair] = {}
-        self._pair_orderbooks: Dict[str, OrderBook] = {}
 
         self.message_queue = message_queue  # type: Queue | None
 
@@ -234,8 +234,6 @@ class Client:
         )
 
         del self._pairs[pair_name]
-        if self._pair_orderbooks.get(pair_name):
-            del self._pair_orderbooks[pair_name]
 
     ######################################################################
     # orderbook methods
@@ -306,8 +304,6 @@ class Client:
         while polling:
             try:
                 order_book = self.get_orderbook(pair_name=pair.name)
-
-                self._pair_orderbooks[pair.name] = order_book
 
                 self.message_queue.put(order_book)
             except PairDoesNotExistException:
@@ -391,13 +387,8 @@ class Client:
     ######################################################################
     # order methods
     ######################################################################
-    # TODO: would be cool if these methods could understand how much they are spending on gas (use TxReceipt)
-    #  also need a way to return the order id for limit orders
-    #  we could listen for the event and return the order id along with relevant gas spend information 
-    #  one thing we will need to be conscious of and figure out how to handle is the fact that gas is calculated in a
-    #  variety of ways depending upon the chain
 
-    def place_market_order(self, transaction: Transaction) -> str:
+    def place_market_order(self, transaction: Transaction) -> TransactionReceipt:
         """Place a market order transaction by executing the specified transaction object. The transaction
         object should contain a single order of type NewMarketOrder. The order is retrieved from the transaction and
         the corresponding market buy or sell method is called based on the order side.
@@ -439,7 +430,7 @@ class Client:
                     max_priority_fee_per_gas=transaction.max_priority_fee_per_gas
                 )
 
-    def place_limit_order(self, transaction: Transaction) -> str:
+    def place_limit_order(self, transaction: Transaction) -> TransactionReceipt:
         """Place a limit order transaction by executing the specified transaction object. The transaction object should
         contain a single order of type NewLimitOrder.
 
@@ -480,7 +471,7 @@ class Client:
                     max_priority_fee_per_gas=transaction.max_priority_fee_per_gas
                 )
 
-    def cancel_limit_order(self, transaction: Transaction) -> str:
+    def cancel_limit_order(self, transaction: Transaction) -> TransactionReceipt:
         """Place a limit order cancel transaction by executing the specified transaction object. The transaction object
         should contain a single order of type NewCancelOrder.
 
@@ -503,7 +494,7 @@ class Client:
             max_priority_fee_per_gas=transaction.max_priority_fee_per_gas
         )
 
-    def batch_place_limit_orders(self, transaction: Transaction) -> str:
+    def batch_place_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Place multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit orders.
@@ -543,7 +534,7 @@ class Client:
             max_priority_fee_per_gas=transaction.max_priority_fee_per_gas
         )
 
-    def batch_update_limit_orders(self, transaction: Transaction) -> str:
+    def batch_update_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Update multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit order updates.
@@ -586,7 +577,7 @@ class Client:
             max_priority_fee_per_gas=transaction.max_priority_fee_per_gas
         )
 
-    def batch_cancel_limit_orders(self, transaction: Transaction) -> str:
+    def batch_cancel_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Cancel multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit order cancellations.

--- a/rubi/rubi/contracts/erc20.py
+++ b/rubi/rubi/contracts/erc20.py
@@ -9,6 +9,7 @@ from web3.contract import Contract
 from web3.types import ABI
 
 from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.types import TransactionReceipt
 from rubi.network import Network
 
 
@@ -176,7 +177,7 @@ class ERC20(BaseContract):
         gas: int = 100000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Approves the spender to spend the amount of the erc20 token from the signer's wallet
 
         :param spender: address of the spender
@@ -194,8 +195,8 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
         approve = self.contract.functions.approve(spender, amount)
 
@@ -216,7 +217,7 @@ class ERC20(BaseContract):
         gas: int = 100000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Transfers the amount of the erc20 token to the recipient
 
         :param recipient: address of the recipient
@@ -233,8 +234,8 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
         transfer = self.contract.functions.transfer(recipient, amount)
 
@@ -256,7 +257,7 @@ class ERC20(BaseContract):
         gas: int = 100000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Transfers the amount of the erc20 token from the sender to the recipient
 
         :param sender: address of the sender
@@ -276,8 +277,8 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
 
         transfer_from = self.contract.functions.transferFrom(sender, recipient, amount)
@@ -299,7 +300,7 @@ class ERC20(BaseContract):
         gas: int = 100000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Increases the allowance of the spender by the added_value
 
         :param spender: address of the spender
@@ -317,8 +318,8 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
         increase_allowance = self.contract.functions.increaseAllowance(spender, added_value)
 
@@ -339,7 +340,7 @@ class ERC20(BaseContract):
         gas: int = 100000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Decreases the allowance of the spender by the subtracted_value
 
         :param spender: address of the spender
@@ -357,8 +358,8 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
         decrease_allowance = self.contract.functions.decreaseAllowance(spender, subtracted_value)
 

--- a/rubi/rubi/contracts/market.py
+++ b/rubi/rubi/contracts/market.py
@@ -5,6 +5,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.types import TransactionReceipt
 from rubi.network import Network
 
 
@@ -226,10 +227,10 @@ class RubiconMarket(BaseContract):
         owner: Optional[ChecksumAddress] = None,
         recipient: Optional[ChecksumAddress] = None,
         nonce: Optional[int] = None,
-        gas: int = 350000,
+        gas: int = 400000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Make a new offer to buy the buy_amt of the buy_gem token in exchange for the pay_amt of the pay_gem token
 
         :param pay_amt: the amount of the token being sold
@@ -262,8 +263,8 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
 
         if not self.signing_permissions:
@@ -291,7 +292,7 @@ class RubiconMarket(BaseContract):
         gas: int = 350000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Cancel an offer by offer id
 
         :param id: the id of the offer to cancel
@@ -307,8 +308,8 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
 
         cancel = self.contract.functions.cancel(id)
@@ -332,7 +333,7 @@ class RubiconMarket(BaseContract):
         gas: int = 350000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Batch the placement of a set of offers in one transaction
 
         :param pay_amts: the amounts of the token being sold
@@ -354,8 +355,8 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
         if not (len(pay_amts) == len(pay_gems) == len(buy_amts) == len(buy_gems)):
             raise Exception("mismatches lengths in pay_amts, pay_gems, buy_amts and buy_gems")
@@ -378,7 +379,7 @@ class RubiconMarket(BaseContract):
         gas: int = 350000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Cancel a set offer by offer id in a single transaction
 
         :param ids: the ids of the offers to cancel
@@ -394,8 +395,8 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
         cancels = self.contract.functions.cancel(ids)
 
@@ -420,7 +421,7 @@ class RubiconMarket(BaseContract):
         gas: int = 350000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Batch update a set of offers in a single transaction and return a list of new offer ids
 
         :param ids: the ids of the offers to cancel
@@ -444,8 +445,8 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
 
         batch_requote = self.contract.functions.batchRequote(ids, pay_amts, pay_gems, buy_amts, buy_gems)
@@ -469,7 +470,7 @@ class RubiconMarket(BaseContract):
         gas: int = 350000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Sell the pay_amt of the pay_gem token in exchange for buy_gem, on the condition that you receive at least the
         min_fill_amount of the buy_gem token
 
@@ -492,8 +493,8 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
         sell_all_amount = self.contract.functions.sellAllAmount(pay_gem, pay_amt, buy_gem, min_fill_amount)
 
@@ -516,7 +517,7 @@ class RubiconMarket(BaseContract):
         gas: int = 350000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Buy the buy_amt of the buy_gem token in exchange for pay_gem, on the condition that it does not exceed the
         max_fill_amount of the pay_gem token
 
@@ -539,8 +540,8 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: transaction hash
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
         buy_all_amount = self.contract.functions.sellAllAmount(buy_gem, buy_amt, pay_gem, max_fill_amount)
 

--- a/rubi/rubi/contracts/router.py
+++ b/rubi/rubi/contracts/router.py
@@ -5,6 +5,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.types import TransactionReceipt
 from rubi.network import Network
 
 
@@ -242,7 +243,7 @@ class RubiconRouter(BaseContract):
         gas: int = 350000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Perform a multiple swaps for the specified payment amounts using the specified routes. Reverts with an
         exception if any of the swaps cannot achieve the buy_amt_min along the specified route.
 
@@ -265,8 +266,8 @@ class RubiconRouter(BaseContract):
         :param max_priority_fee_per_gas: Max priority fee that can be paid for gas. Defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None).
         :type max_priority_fee_per_gas: Optional[int]
-        :return: Transaction hash.
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
 
         multiswap = self.contract.functions.multiswap(routes, pay_amts, buy_amts_min, to)
@@ -290,7 +291,7 @@ class RubiconRouter(BaseContract):
         gas: int = 350000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
-    ) -> str:
+    ) -> TransactionReceipt:
         """Perform a swap operation with the specified payment amount using the specified route and paying out to the
         recipient. Reverts if the swap does not result in the buy_min_amount.
 
@@ -313,8 +314,8 @@ class RubiconRouter(BaseContract):
         :param max_priority_fee_per_gas: Max priority fee that can be paid for gas. Defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None).
         :type max_priority_fee_per_gas: Optional[int]
-        :return: Transaction hash.
-        :rtype: str
+        :return: An object representing the transaction receipt
+        :rtype: TransactionReceipt
         """
 
         swap = self.contract.functions.swap(pay_amt, buy_amt_min, route, to)

--- a/rubi/rubi/contracts/types/__init__.py
+++ b/rubi/rubi/contracts/types/__init__.py
@@ -1,1 +1,2 @@
 from .events import *
+from .transaction_reciept import TransactionReceipt

--- a/rubi/rubi/contracts/types/transaction_reciept.py
+++ b/rubi/rubi/contracts/types/transaction_reciept.py
@@ -18,7 +18,11 @@ class TransactionReceipt:
         to_address: ChecksumAddress,
         status: int,
         transaction_hash: HexBytes,
-        transaction_index: int
+        transaction_index: int,
+        l1_fee: Optional[int] = None,
+        l1_gas_price: Optional[int] = None,
+        l1_gas_used: Optional[int] = None,
+        l1_fee_scalar: Optional[int] = None
     ):
         self.block_number = block_number
         self.contract_address = contract_address
@@ -29,6 +33,10 @@ class TransactionReceipt:
         self.status = status
         self.transaction_hash = transaction_hash
         self.transaction_index = transaction_index
+        self.l1_fee = l1_fee
+        self.l1_gas_price = l1_gas_price
+        self.l1_gas_used = l1_gas_used
+        self.l1_fee_scalar = l1_fee_scalar
 
     @classmethod
     def from_tx_receipt(cls, tx_receipt: TxReceipt) -> "TransactionReceipt":
@@ -41,7 +49,11 @@ class TransactionReceipt:
             to_address=tx_receipt["to"],
             status=tx_receipt["status"],
             transaction_hash=tx_receipt["transactionHash"],
-            transaction_index=tx_receipt["transactionIndex"]
+            transaction_index=tx_receipt["transactionIndex"],
+            l1_fee=None if tx_receipt.get("l1Fee") is None else int(tx_receipt.get("l1Fee"), 16),
+            l1_gas_price=None if tx_receipt.get("l1GasPrice") is None else int(tx_receipt.get("l1GasPrice"), 16),
+            l1_gas_used=None if tx_receipt.get("l1GasUsed") is None else int(tx_receipt.get("l1GasUsed"), 16),
+            l1_fee_scalar=None if tx_receipt.get("l1FeeScalar") is None else int(tx_receipt.get("l1FeeScalar"), 16)
         )
 
     def __repr__(self):

--- a/rubi/rubi/contracts/types/transaction_reciept.py
+++ b/rubi/rubi/contracts/types/transaction_reciept.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+from eth_typing import BlockNumber, ChecksumAddress
+from hexbytes import HexBytes
+from web3.types import Wei, TxReceipt
+
+
+# TODO: a TxReceipt contains logs which can be decoded into events that were emitted by calling the contract function.
+#  It may be useful in future to add the logs field to the TransactionReceipt object and decode them into objects.
+class TransactionReceipt:
+    def __init__(
+        self,
+        block_number: BlockNumber,
+        contract_address: Optional[ChecksumAddress],
+        effective_gas_price: Wei,
+        gas_used: int,
+        from_address: ChecksumAddress,
+        to_address: ChecksumAddress,
+        status: int,
+        transaction_hash: HexBytes,
+        transaction_index: int
+    ):
+        self.block_number = block_number
+        self.contract_address = contract_address
+        self.effective_gas_price = effective_gas_price
+        self.gas_used = gas_used
+        self.from_address = from_address
+        self.to_address = to_address
+        self.status = status
+        self.transaction_hash = transaction_hash
+        self.transaction_index = transaction_index
+
+    @classmethod
+    def from_tx_receipt(cls, tx_receipt: TxReceipt) -> "TransactionReceipt":
+        return cls(
+            block_number=tx_receipt["blockNumber"],
+            contract_address=tx_receipt["contractAddress"],
+            effective_gas_price=tx_receipt["effectiveGasPrice"],
+            gas_used=tx_receipt["gasUsed"],
+            from_address=tx_receipt["from"],
+            to_address=tx_receipt["to"],
+            status=tx_receipt["status"],
+            transaction_hash=tx_receipt["transactionHash"],
+            transaction_index=tx_receipt["transactionIndex"]
+        )
+
+    def __repr__(self):
+        items = ("{}={!r}".format(k, self.__dict__[k]) for k in self.__dict__)
+        return "{}({})".format(type(self).__name__, ", ".join(items))

--- a/rubi/rubi/types/order.py
+++ b/rubi/rubi/types/order.py
@@ -197,7 +197,7 @@ class Transaction:
         self,
         orders: List[BaseNewOrder],
         nonce: Optional[int] = None,
-        gas: int = 350000,
+        gas: int = 3500000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
     ):


### PR DESCRIPTION
This allows the client to be gas aware so that systems built on top of it can understand their gas spend.