### PR TITLE
update: transaction receipt fee scalar type

### DIFF
--- a/rubi/rubi/contracts/contract_types/transaction_reciept.py
+++ b/rubi/rubi/contracts/contract_types/transaction_reciept.py
@@ -22,7 +22,7 @@ class TransactionReceipt:
         l1_fee: Optional[int] = None,
         l1_gas_price: Optional[int] = None,
         l1_gas_used: Optional[int] = None,
-        l1_fee_scalar: Optional[int] = None
+        l1_fee_scalar: Optional[float] = None
     ):
         self.block_number = block_number
         self.contract_address = contract_address
@@ -40,6 +40,7 @@ class TransactionReceipt:
 
     @classmethod
     def from_tx_receipt(cls, tx_receipt: TxReceipt) -> "TransactionReceipt":
+
         return cls(
             block_number=tx_receipt["blockNumber"],
             contract_address=tx_receipt["contractAddress"],
@@ -53,7 +54,7 @@ class TransactionReceipt:
             l1_fee=None if tx_receipt.get("l1Fee") is None else int(tx_receipt.get("l1Fee"), 16),
             l1_gas_price=None if tx_receipt.get("l1GasPrice") is None else int(tx_receipt.get("l1GasPrice"), 16),
             l1_gas_used=None if tx_receipt.get("l1GasUsed") is None else int(tx_receipt.get("l1GasUsed"), 16),
-            l1_fee_scalar=None if tx_receipt.get("l1FeeScalar") is None else int(tx_receipt.get("l1FeeScalar"), 16)
+            l1_fee_scalar=None if tx_receipt.get("l1FeeScalar") is None else float(tx_receipt.get("l1FeeScalar"))
         )
 
     def __repr__(self):


### PR DESCRIPTION
currently, in the `from_tx_receipt` constructor we have the `l1FeeScalar` set to be an int. this causes errors on optimism mainnet today. see below: 

here is an example output from an optimism mainnet transaction (`0x9690290b530be27e5167b0eb70c34abded086b2867934bae7aad0d86a0d56927`):  `AttributeDict({... 'gasUsed': 33155, 'l1Fee': '0x1e572960650a', 'l1FeeScalar': '0.684', 'l1GasPrice': '0x49bcaca6b', ...})`