### PR TITLE
fix: increase default gas specified for functions on the market.py so that Market Makers don't encounter out of gas errors.

### DIFF
--- a/rubi/rubi/contracts/market.py
+++ b/rubi/rubi/contracts/market.py
@@ -227,7 +227,7 @@ class RubiconMarket(BaseContract):
         owner: Optional[ChecksumAddress] = None,
         recipient: Optional[ChecksumAddress] = None,
         nonce: Optional[int] = None,
-        gas: int = 400000,
+        gas: int = 3500000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
     ) -> TransactionReceipt:
@@ -330,7 +330,7 @@ class RubiconMarket(BaseContract):
         buy_amts: List[int],
         buy_gems: List[ChecksumAddress],
         nonce: Optional[int] = None,
-        gas: int = 3500000,
+        gas: int = 5000000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
     ) -> TransactionReceipt:
@@ -418,7 +418,7 @@ class RubiconMarket(BaseContract):
         buy_amts: List[int],
         buy_gems: List[ChecksumAddress],
         nonce: Optional[int] = None,
-        gas: int = 800000,
+        gas: int = 5000000,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None
     ) -> TransactionReceipt:


### PR DESCRIPTION
## Description

Temp fix to increase the default gas values on the `market.py` functions to ensure Market Makers don't encounter out of gas errors.

This highlights the need to focus on fixing this issue: https://github.com/RubiconDeFi/rubi-py/issues/6

## What was the issue?

Market makers encountering failed transactions due to `out of gas` errors because the default values for gas are too low.

## What were the changes?

Increase the default values.

## What type of change was this 

- [X] fix - fixing bugs and adding small changes (X.X.X+1)
- [ ] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)
