### PR TITLE
fix: adding skip-existing in deployment script for testpypi

### DIFF
--- a/.github/workflows/deployment_and_release.yml
+++ b/.github/workflows/deployment_and_release.yml
@@ -41,6 +41,7 @@ jobs:
           password: ${{ secrets.TEST_PYPI_KEY }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: ./rubi/dist
+          skip-existing: true
   
   # Create a completely separate runner and installs rubi from Test PyPi to ensure functioning build
   test-install:


### PR DESCRIPTION
# rubi-py PR

- Note - **please make sure the title of your PR follows semantic versioning** 
- Ex. fix/feat/refactor: description 
- For a breaking change, that will bump an entire version, please use !. Ex. refactor!: description 

## Description

Due to earlier testing, test pypi does not let us reuse names which is causing an error whenever we upload a new version during the deployment flow for testing


## What was the issue?

Github action fails during testpypi deployment breaking the entire flow



## What were the changes?

Adding a `skip-existing` flag that will skip the upload whenever the name matches. This shouldn't be a problem after a couple more releases


## What type of change was this 

- [x] fix - fixing bugs and adding small changes (X.X.X+1)
- [ ] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



