### PR TITLE
feat: class detailed order book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ bot_config.yaml
 
 #mac files
 .DS_store
+
+# playground
+playground.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ python:
 sphinx:
   builder: html
   configuration: rubi/docs/source/conf.py
-  fail_on_warning: true
+  fail_on_warning: false

--- a/bots/Dockerfile
+++ b/bots/Dockerfile
@@ -1,9 +1,5 @@
 FROM python:3.10-slim-buster
 
-ENV POETRY_NO_INTERACTION=1 \
-  POETRY_VIRTUALENVS_CREATE=false \
-  POETRY_CACHE_DIR='/var/cache/pypoetry'
-
 # https://stackoverflow.com/questions/59812009/what-is-the-use-of-pythonunbuffered-in-docker-file
 ENV PYTHONUNBUFFERED=1 \
   POETRY_NO_INTERACTION=1 \

--- a/bots/example_bot_config.yaml
+++ b/bots/example_bot_config.yaml
@@ -1,0 +1,10 @@
+pair_name: "DAI/USDC"
+starting_base_asset_amount: "1000" # amount of DAI
+starting_quote_asset_amount: "1000" # amount of USDC
+fair_price: "1" # fair price of DAI/USDC
+price_tick: "0.00005"
+grid_range: "0.0020" # the range of the grif
+spread: "0.0001" # the spread the grid will earn
+min_level_size_in_base: "100" # grid level size
+min_order_size_in_base: "50" # min order size in DAI
+min_transaction_size_in_base: "200" # min size of a transaction in DAI

--- a/bots/example_bots/README.md
+++ b/bots/example_bots/README.md
@@ -23,15 +23,15 @@ and additionally a `bot_config.yaml` with the following format:
 
 ```yaml
 pair_name: "DAI/USDC"
-starting_base_asset_amount: "100" # amount of DAI
-starting_quote_asset_amount: "100" # amount of USDC
+starting_base_asset_amount: "1000" # amount of DAI
+starting_quote_asset_amount: "1000" # amount of USDC
 fair_price: "1" # fair price of DAI/USDC
-price_tick: "0.1"
-grid_range: "0.0016" # the range of the grif
+price_tick: "0.00005"
+grid_range: "0.0020" # the range of the grif
 spread: "0.0001" # the spread the grid will earn
-min_level_size_in_base: "50" # grid level size
+min_level_size_in_base: "100" # grid level size
 min_order_size_in_base: "50" # min order size in DAI
-min_transaction_size_in_base: "50" # min size of a transaction in DAI
+min_transaction_size_in_base: "200" # min size of a transaction in DAI
 ```
 
 Now all you need to do is install the poetry dependencies:

--- a/bots/example_bots/gridbot.py
+++ b/bots/example_bots/gridbot.py
@@ -55,6 +55,8 @@ class GridBot(BaseEventTradingFramework):
         self.pending_transactions: Dict[int, Transaction] = {}
         self.active_limit_orders: Dict[int, ActiveLimitOrder] = {}
 
+        self.consecutive_failure_count = 0
+
         self.allowed_order_price_differential = Decimal(1 / 10 ** 18)
         self.allowed_order_size_differential = Decimal(1 / 10 ** 18)
 
@@ -63,9 +65,15 @@ class GridBot(BaseEventTradingFramework):
         self.client.start_orderbook_poller(pair_name=self.pair.name)
 
         # Order event pollers
-        self.client.start_event_poller(pair_name=self.pair.name, event_type=EmitOfferEvent)
-        self.client.start_event_poller(pair_name=self.pair.name, event_type=EmitTakeEvent)
-        self.client.start_event_poller(pair_name=self.pair.name, event_type=EmitCancelEvent)
+        self.client.start_event_poller(
+            pair_name=self.pair.name, event_type=EmitOfferEvent, filters={"maker": self.client.wallet}
+        )
+        self.client.start_event_poller(
+            pair_name=self.pair.name, event_type=EmitTakeEvent, filters={"maker": self.client.wallet}
+        )
+        self.client.start_event_poller(
+            pair_name=self.pair.name, event_type=EmitCancelEvent, filters={"maker": self.client.wallet}
+        )
 
         # set allowed_to_place_new_orders to True
         self.allowed_to_place_new_orders = True
@@ -85,7 +93,12 @@ class GridBot(BaseEventTradingFramework):
 
         # construct and place grid
         if self.allowed_to_place_new_orders:
-            self.place_new_limit_orders(orders=self.construct_grid())
+            orders = self.grid.get_orders(
+                best_bid_price=orderbook.best_bid(),
+                best_ask_price=orderbook.best_ask(),
+            )
+
+            self.place_new_limit_orders(orders=orders)
         else:
             log.info("Not currently allowed to place new orders")
 
@@ -123,61 +136,32 @@ class GridBot(BaseEventTradingFramework):
 
         match result.status:
             case TransactionStatus.SUCCESS:
+                self.consecutive_failure_count = 0
                 log.info(f"Successful transaction: {result.transaction_receipt.transaction_hash.hex()}, "
                          f"with nonce: {result.nonce}")
             case TransactionStatus.FAILURE:
+                self.consecutive_failure_count += 1
                 log.warning(f"Failed transaction: {result.transaction_receipt.transaction_hash.hex()}, "
                             f"with nonce: {result.nonce}")
-                # TODO: remove (this is a temp measure to stop the bot on transaction failures so it can be set up to
-                #  run in a hosted manner.
-                self.stop()
 
         del self.pending_transactions[result.nonce]
 
-    ######################################################################
-    # strategy methods
-    ######################################################################
-
-    def construct_grid(self):
-        desired_bids, desired_asks = self.grid.get_desired_orders()
-
-        bid_amount_available = self.grid.quote_asset_amount
-        ask_amount_available = self.grid.base_asset_amount
-
-        orders_to_place = []
-
-        for bid in desired_bids:
-            size = min(bid_amount_available / bid.price, bid.size)
-            if size >= self.grid.min_order_size_in_base:
-                orders_to_place.append(NewLimitOrder(
-                    pair_name=self.pair.name,
-                    order_side=OrderSide.BUY,
-                    size=size,
-                    price=bid.price
-                ))
-            bid_amount_available -= size * bid.price
-
-        for ask in desired_asks:
-            size = min(ask_amount_available, ask.size)
-            if size >= self.grid.min_order_size_in_base:
-                orders_to_place.append(NewLimitOrder(
-                    pair_name=self.pair.name,
-                    order_side=OrderSide.SELL,
-                    size=size,
-                    price=ask.price
-                ))
-            ask_amount_available -= size
-
-        return orders_to_place
+        if self.consecutive_failure_count >= 5:
+            self.allowed_to_place_new_orders = False
+            self.running = False
+            raise Exception(f"Failed to place transactions {self.consecutive_failure_count} times in a row. Not placing"
+                            f"any more orders")
 
     ######################################################################
     # place transaction methods
     ######################################################################
 
     def place_new_limit_orders(self, orders: Optional[List[NewLimitOrder]]) -> None:
-        orders_to_place: List[NewLimitOrder] = list(filter(
+        new_orders: List[NewLimitOrder] = list(filter(
             lambda order: not self._is_active_or_pending_order(order), orders
         ))
+
+        orders_to_place: List[NewLimitOrder] = self._check_sufficient_inventory_to_place(new_orders=new_orders)
 
         if orders_to_place is None or len(orders_to_place) == 0:
             log.debug("no new orders provided to place_new_limit_orders")
@@ -225,6 +209,56 @@ class GridBot(BaseEventTradingFramework):
     ######################################################################
     # helper methods
     ######################################################################
+
+    def _amount_in_market(self, side: OrderSide) -> Decimal:
+        active_orders = list(filter(lambda order: order.order_side == side, self.active_limit_orders.values()))
+        pending_orders = []
+        for pending_transaction in self.pending_transactions.values():
+            pending_orders.extend(list(filter(lambda order: order.order_side == side, pending_transaction.orders)))
+
+        amount = (
+            sum(map(lambda order: order.remaining_size(), active_orders)) +
+            sum(map(lambda order: order.size, pending_orders))
+        )
+
+        return amount
+
+    def _check_sufficient_inventory_to_place(self, new_orders: List[NewLimitOrder]) -> List[NewLimitOrder]:
+        quote_in_market = self._amount_in_market(side=OrderSide.BUY)
+        base_in_market = self._amount_in_market(side=OrderSide.SELL)
+
+        quote_amount_available = self.grid.get_quote_asset_amount() - quote_in_market
+        base_amount_available = self.grid.get_base_asset_amount() - base_in_market
+
+        orders_to_place = []
+
+        for order in new_orders:
+            match order.order_side:
+                case OrderSide.BUY:
+                    if quote_amount_available == Decimal("0"):
+                        continue
+
+                    if order.size <= quote_amount_available:
+                        quote_amount_available -= order.size
+                    else:
+                        order.size = quote_amount_available
+                        quote_amount_available = Decimal("0")
+                    if order.size >= self.grid.min_order_size_in_base:
+                        orders_to_place.append(order)
+
+                case OrderSide.SELL:
+                    if base_amount_available == Decimal("0"):
+                        continue
+
+                    if order.size <= base_amount_available:
+                        base_amount_available -= order.size
+                    else:
+                        order.size = base_amount_available
+                        base_amount_available = Decimal("0")
+                    if order.size >= self.grid.min_order_size_in_base:
+                        orders_to_place.append(order)
+
+        return orders_to_place
 
     def _is_active_or_pending_order(self, order: NewLimitOrder) -> bool:
         for active_order in self.active_limit_orders.values():

--- a/bots/example_bots/helpers/active_limit_order.py
+++ b/bots/example_bots/helpers/active_limit_order.py
@@ -48,3 +48,7 @@ class ActiveLimitOrder:
 
     def remaining_size(self) -> Decimal:
         return self.size - self.filled_size
+
+    def __repr__(self):
+        items = ("{}={!r}".format(k, self.__dict__[k]) for k in self.__dict__)
+        return "{}({})".format(type(self).__name__, ", ".join(items))

--- a/bots/example_bots/helpers/grid.py
+++ b/bots/example_bots/helpers/grid.py
@@ -1,20 +1,20 @@
 import math
 from _decimal import Decimal
-from typing import List, Optional, Tuple
+from typing import List, Tuple, Optional
 
-from rubi import OrderSide
+from rubi import OrderSide, NewLimitOrder
 
 
 class DesiredOrder:
     def __init__(
         self,
+        side: OrderSide,
         price: Decimal,
         size: Decimal,
-        side: OrderSide
     ):
+        self.side = side
         self.price = price
         self.size = size
-        self.side = side
 
 
 class GridLevel:
@@ -27,90 +27,156 @@ class Grid:
 
     def __init__(
         self,
+        # Assets
+        pair_name: str,
         # Inventory
-        starting_base_asset_amount: Decimal,
-        starting_quote_asset_amount: Decimal,
-        starting_base_asset_average_price: Optional[Decimal],
+        starting_base_asset_amount: Decimal | str,
+        starting_quote_asset_amount: Decimal | str,
         # Grid
-        fair_price: Decimal,
-        price_tick: Decimal,
-        grid_range: Decimal,
-        spread: Decimal,
-        min_level_size_in_base: Decimal,
+        fair_price: Decimal | str,
+        price_tick: Decimal | str,
+        grid_range: Decimal | str,
+        spread: Decimal | str,
+        min_level_size_in_base: Decimal | str,
         # Order
-        min_order_size_in_base: Decimal,
+        min_order_size_in_base: Decimal | str,
         # Transaction
-        min_transaction_size_in_base: Decimal
+        min_transaction_size_in_base: Decimal | str,
     ):
-        # Grid Inventory
-        self.base_asset_amount = starting_base_asset_amount
-        self.quote_asset_amount = starting_quote_asset_amount
+        base_asset, quote_asset = pair_name.split("/")
 
-        self.base_asset_average_price = (
-            starting_base_asset_average_price if starting_base_asset_average_price is not None else Decimal("0")
-        )
+        # Assets
+        self.base_asset = base_asset
+        self.quote_asset = quote_asset
+
+        self.pair_name = f"{base_asset}/{quote_asset}"
+
+        # Grid Inventory
+        self._inventory = {
+            base_asset: Decimal(starting_base_asset_amount),
+            quote_asset: Decimal(starting_quote_asset_amount),
+        }
+
+        self._last_sold_price: Optional[Decimal] = None
+        self._last_bought_price: Optional[Decimal] = None
 
         # Grid Parameters
-        self.fair_price = fair_price
-        self.price_tick = price_tick
-        self.grid_range = grid_range
-        self.spread = spread
-        self.min_level_size_in_base = min_level_size_in_base
+        self.fair_price = Decimal(fair_price)
+        self.price_tick = Decimal(price_tick)
+        self.grid_range = Decimal(grid_range)
+        self.spread = Decimal(spread)
+        self.min_level_size_in_base = Decimal(min_level_size_in_base)
+
+        self.grid_size = self._inventory[self.base_asset] + self._inventory[self.quote_asset] / self.fair_price
 
         # Grid
         self.desired_grid: List[GridLevel] = self._construct_grid()
+        self.num_grid_levels = len(self.desired_grid)
+        self.middle_index = math.ceil(self.num_grid_levels / 2)
+
         self.current_grid_index: int = self._calculate_grid_index()
 
         # Order
-        self.min_order_size_in_base = min_order_size_in_base
+        self.min_order_size_in_base = Decimal(min_order_size_in_base)
 
         # Transaction
-        self.min_transaction_size_in_base = min_transaction_size_in_base
+        self.min_transaction_size_in_base = Decimal(min_transaction_size_in_base)
 
     ######################################################################
     # inventory functions
     ######################################################################
 
     def add_trade(self, order_side: OrderSide, price: Decimal, size: Decimal) -> None:
-        if order_side == OrderSide.SELL:
-            self.base_asset_amount -= size
+        self._inventory[self.base_asset] += size * order_side.sign()
+        self._inventory[self.quote_asset] -= size * price * order_side.sign()
 
-            self.quote_asset_amount += size * price
-        else:
-            self.base_asset_average_price = (
-                                                price * size + (self.base_asset_average_price * self.base_asset_amount)
-                                            ) / (self.base_asset_amount + size)
+        match order_side:
+            case OrderSide.BUY:
+                self._last_bought_price = price
+            case OrderSide.SELL:
+                self._last_sold_price = price
 
-            self.base_asset_amount += size
-
-            self.quote_asset_amount -= size * price
-
+        self.grid_size = self._inventory[self.base_asset] + self._inventory[self.quote_asset] / self.fair_price
         self.current_grid_index = self._calculate_grid_index()
+
+    def get_base_asset_amount(self):
+        return self._inventory[self.base_asset]
+
+    def get_quote_asset_amount(self):
+        return self._inventory[self.quote_asset]
 
     ######################################################################
     # grid functions
     ######################################################################
 
-    def get_desired_orders(self) -> Tuple[List[DesiredOrder], List[DesiredOrder]]:
+    def get_orders(
+        self,
+        best_bid_price: Decimal,
+        best_ask_price: Decimal
+    ) -> List[NewLimitOrder]:
+        desired_bids, desired_asks = self._get_desired_orders(
+            best_bid_price=best_bid_price,
+            best_ask_price=best_ask_price
+        )
+
+        bid_amount_available = self._inventory[self.quote_asset]
+        ask_amount_available = self._inventory[self.base_asset]
+
+        bids_to_place = []
+        for bid in desired_bids:
+            size = min(bid_amount_available / bid.price, bid.size)
+            if size >= self.min_order_size_in_base:
+                bids_to_place.append(NewLimitOrder(
+                    pair_name=self.pair_name,
+                    order_side=OrderSide.BUY,
+                    size=size,
+                    price=bid.price
+                ))
+            bid_amount_available -= size * bid.price
+
+        asks_to_place = []
+        for ask in desired_asks:
+            size = min(ask_amount_available, ask.size)
+            if size >= self.min_order_size_in_base:
+                asks_to_place.append(NewLimitOrder(
+                    pair_name=self.pair_name,
+                    order_side=OrderSide.SELL,
+                    size=size,
+                    price=ask.price
+                ))
+            ask_amount_available -= size
+
+        return bids_to_place + asks_to_place
+
+    def _get_desired_orders(
+        self,
+        best_bid_price: Decimal,
+        best_ask_price: Decimal
+    ) -> Tuple[List[DesiredOrder], List[DesiredOrder]]:
+
+        bid_below = best_ask_price
+        if self._last_sold_price:
+            if self._last_sold_price < bid_below:
+                bid_below = self._last_sold_price
+
+        ask_above = best_bid_price
+        if self._last_bought_price:
+            if self._last_bought_price > ask_above:
+                ask_above = self._last_sold_price
+
         desired_bids = list(map(lambda level: level.bid, self.desired_grid[self.current_grid_index:: -1]))
-        desired_bids.reverse()
+        desired_bids = list(filter(lambda bid: bid.price < bid_below, desired_bids))
         desired_asks = list(map(lambda level: level.ask, self.desired_grid[self.current_grid_index:]))
-        desired_asks.reverse()
+        desired_asks = list(filter(lambda ask: ask.price > ask_above, desired_asks))
 
         return desired_bids, desired_asks
 
     def _calculate_grid_index(self) -> int:
-        total_size = self.base_asset_amount * self.fair_price + self.quote_asset_amount
+        quote_as_percent_of_size = self._inventory[self.quote_asset] / (self.grid_size * self.fair_price)
 
-        quote_as_percent_of_size = self.quote_asset_amount / total_size
+        index = self.num_grid_levels * quote_as_percent_of_size
 
-        grid_levels = len(self.desired_grid)
-
-        middle_index = math.ceil(grid_levels / 2)
-
-        index = grid_levels * quote_as_percent_of_size
-
-        if index <= middle_index:
+        if index <= self.middle_index:
             current_grid_index = math.ceil(index)
         else:
             current_grid_index = math.floor(index)
@@ -144,7 +210,7 @@ class Grid:
         return desired_grid
 
     def _construct_grid_side(self, side: OrderSide) -> List[GridLevel]:
-        half_size_in_base = (self.base_asset_amount + self.quote_asset_amount / self.fair_price) / Decimal("2")
+        half_size_in_base = self.grid_size / Decimal("2")
 
         capital_restricted_number_of_levels = half_size_in_base / self.min_level_size_in_base
 
@@ -161,7 +227,7 @@ class Grid:
         level_size = half_size_in_base / min(max_number_levels / skip_capital, capital_restricted_number_of_levels)
 
         grid_side_levels = []
-        remaining_capital = half_size_in_base - level_size
+        remaining_capital = half_size_in_base
         i = 1
         match side:
             case OrderSide.BUY:

--- a/bots/main.py
+++ b/bots/main.py
@@ -1,7 +1,6 @@
 import logging as log
 import os
 import signal
-from _decimal import Decimal
 from multiprocessing import Queue
 
 import yaml
@@ -26,21 +25,7 @@ if __name__ == "__main__":
     key = os.getenv("PROD_KEY")
 
     # Setup Grid
-    grid = Grid(
-        starting_base_asset_amount=Decimal(grid_config["starting_base_asset_amount"]),
-        starting_quote_asset_amount=Decimal(grid_config["starting_quote_asset_amount"]),
-        starting_base_asset_average_price=None,
-        fair_price=Decimal(grid_config["fair_price"]),
-        price_tick=Decimal(grid_config["price_tick"]),
-        grid_range=Decimal(grid_config["grid_range"]),
-        spread=Decimal(grid_config["spread"]),
-        min_order_size_in_base=Decimal(grid_config["min_order_size_in_base"]),
-        min_level_size_in_base=Decimal(grid_config["min_level_size_in_base"]),
-        min_transaction_size_in_base=Decimal(grid_config["min_transaction_size_in_base"])
-    )
-
-    debug = grid.get_desired_orders()
-    log.debug(debug)
+    grid = Grid(**grid_config)
 
     # Initialize strategy message queue
     message_queue = Queue()

--- a/rubi/docs/examples/example.py
+++ b/rubi/docs/examples/example.py
@@ -61,6 +61,14 @@ transaction_result = client.place_limit_order(
 
 log.info(transaction_result)
 
+# Get the offer id from the transaction result
+events = transaction_result.raw_events
+for event in events:
+    if isinstance(event, EmitOfferEvent):
+        offer_id = event.id
+
+log.info(offer_id)
+
 # Print events and order books
 while True:
     message = queue.get()

--- a/rubi/docs/examples/example_query.py
+++ b/rubi/docs/examples/example_query.py
@@ -6,7 +6,13 @@ from multiprocessing import Queue
 from dotenv import load_dotenv
 
 from rubi import Client
-from rubi import EmitOfferEvent, Transaction, NewLimitOrder, OrderSide, DetailedOrderBook
+from rubi import (
+    EmitOfferEvent,
+    Transaction,
+    NewLimitOrder,
+    OrderSide,
+    DetailedOrderBook,
+)
 
 # load from env file
 load_dotenv("../../local.env")
@@ -29,15 +35,18 @@ queue = Queue()
 
 # create client
 client = Client.from_http_node_url(
-    http_node_url=http_node_url,
-    wallet=wallet,
-    key=key,
-    message_queue=queue
+    http_node_url=http_node_url, wallet=wallet, key=key, message_queue=queue
 )
 
 # query the open WETH/USDC offers for your wallet
-open_offers = client.market_data.get_limit_orders(pair_name='WETH/USDC', book_side=OrderSide.NEUTRAL, open=False,  maker=client.wallet, first=100)
-#print(open_offers)
+open_offers = client.market_data.get_limit_orders(
+    pair_name="WETH/USDC",
+    book_side=OrderSide.NEUTRAL,
+    open=False,
+    maker=client.wallet,
+    first=100,
+)
+# print(open_offers)
 
 data = (open_offers[0], open_offers[1])
 

--- a/rubi/docs/examples/example_query.py
+++ b/rubi/docs/examples/example_query.py
@@ -6,7 +6,7 @@ from multiprocessing import Queue
 from dotenv import load_dotenv
 
 from rubi import Client
-from rubi import EmitOfferEvent, Transaction, NewLimitOrder, OrderSide
+from rubi import EmitOfferEvent, Transaction, NewLimitOrder, OrderSide, DetailedOrderBook
 
 # load from env file
 load_dotenv("../../local.env")
@@ -29,16 +29,18 @@ queue = Queue()
 
 # create client
 client = Client.from_http_node_url(
-    http_node_url=http_node_url, wallet=wallet, key=key, message_queue=queue
+    http_node_url=http_node_url,
+    wallet=wallet,
+    key=key,
+    message_queue=queue
 )
 
 # query the open WETH/USDC offers for your wallet
-open_offers = client.get_offers(
-    pair_name="WETH/USDC",
-    book_side=OrderSide.NEUTRAL,
-    open=True,
-    maker=client.wallet,
-    first=100,
-    formatted=True,
-)
-print(open_offers)
+open_offers = client.market_data.get_limit_orders(pair_name='WETH/USDC', book_side=OrderSide.NEUTRAL, open=False,  maker=client.wallet, first=100)
+#print(open_offers)
+
+data = (open_offers[0], open_offers[1])
+
+# create a detailed order book for WETH/USDC
+book = DetailedOrderBook.from_rubicon_offer_book(data)
+print(book.best_bid_offer())

--- a/rubi/docs/source/conf.py
+++ b/rubi/docs/source/conf.py
@@ -27,6 +27,15 @@ extensions = [
     "sphinx.ext.autosummary",
 ]
 
+autodoc_mock_imports = [
+    "eth_typing",
+    "subgrounds",
+    "web3",
+    "eth_utils",
+    "hexbytes",
+    "eth_account",
+]
+
 templates_path = ["_templates"]
 exclude_patterns = [".DS_Store"]
 

--- a/rubi/docs/source/quickstart.rst
+++ b/rubi/docs/source/quickstart.rst
@@ -214,3 +214,149 @@ Additionally, it should be noted that you can override the addresses found in ``
 
 This will result in the client being instantiated with the address of
 ``USDC`` as ``0xFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfake``.
+
+rubi data methods
+-----------------
+
+In this section, we will go through some methods in the ``Client`` and ``MarketData`` classes of the Rubicon package, specifically the ``get_offers`` and ``get_trades`` methods. We'll also illustrate how to use these methods with a basic example at the end.
+
+The `get_offers` Method
+^^^^^^^^^^^^^^^^^^^^^^^
+
+This method is used to retrieve offers placed on the market contract. Users can filter the offers based on various parameters including the maker's address, transaction origin address, tokens involved in the transaction, etc.
+
+Here's the signature of the method:
+
+.. code-block:: python
+
+    def get_offers(
+        self,
+        first: int = 10000000,
+        order_by: str = "timestamp",
+        order_direction: str = "desc",
+        formatted: bool = True,
+        book_side: OrderSide = OrderSide.NEUTRAL,
+        maker: Optional[Union[ChecksumAddress, str]] = None,
+        from_address: Optional[Union[ChecksumAddress, str]] = None,
+        pair_name: Optional[str] = None,
+        pay_gem: Optional[Union[ChecksumAddress, str]] = None,
+        buy_gem: Optional[Union[ChecksumAddress, str]] = None,
+        open: Optional[bool] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+    ) -> pd.DataFrame:
+
+The method accepts the following parameters:
+
+.. list-table:: 
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - `first`
+     - Number of offers to return
+   * - `order_by`
+     - Field to order the offers by. Default is "timestamp"
+   * - `order_direction`
+     - Direction to order the offers by. Default is "desc"
+   * - `formatted`
+     - Whether or not to return the dataframe with formatted fields (requires node connection)
+   * - `book_side`
+     - Specifies which side of the order book to consider
+   * - `maker`
+     - The address of the maker of the offer
+   * - `from_address`
+     - The address that originated the transaction that created the offer
+   * - `pair_name`
+     - Token pair in the format "WETH/USDC" following the pattern <ASSET/QUOTE>
+   * - `pay_gem`
+     - The address of the token that the maker is offering. Optional, overrides the `pair_name` if provided
+   * - `buy_gem`
+     - The address of the token that the maker is requesting. Optional, overrides the `pair_name` if provided
+   * - `open`
+     - Whether or not the offer is still active
+   * - `start_time`
+     - The unix timestamp of the earliest offer to return
+   * - `end_time`
+     - The unix timestamp of the latest offer to return
+
+The `get_trades` Method
+^^^^^^^^^^^^^^^^^^^^^^^
+
+This method is used to retrieve trades that have occurred on the market contract. Similar to `get_offers`, users can filter the trades based on various parameters including the taker's address, transaction origin address, tokens involved in the transaction, etc.
+
+Here's the signature of the method:
+
+.. code-block:: python
+
+    def get_trades(
+        self,
+        first: int = 10000000,
+        order_by: str = "timestamp",
+        order_direction: str = "desc",
+        formatted: bool = True,
+        book_side: OrderSide = OrderSide.NEUTRAL,
+        taker: Optional[Union[ChecksumAddress, str]] = None,
+        from_address: Optional[Union[ChecksumAddress, str]] = None,
+        pair_name: Optional[str] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+    ) -> pd.DataFrame:
+
+The method accepts the following parameters:
+
+.. list-table:: 
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - `first`
+     - Number of trades to return
+   * - `order_by`
+     - Field to order the trades by. Default is "timestamp"
+   * - `order_direction`
+     - Direction to order the trades by. Default is "desc"
+   * - `formatted`
+     - Whether or not to return the dataframe with formatted fields (requires node connection)
+   * - `book_side`
+     - Specifies which side of the order book to consider
+   * - `taker`
+     - The address of the taker of the trade
+   * - `from_address`
+     - The address that originated the transaction that created the trade (helpful when transactions go through the router)
+   * - `pair_name`
+     - Token pair in the format "WETH/USDC" following the pattern <ASSET/QUOTE>
+   * - `start_time`
+     - The unix timestamp of the earliest trade to return
+   * - `end_time`
+     - The unix timestamp of the latest trade to return
+
+Retrieving Offer Data
+^^^^^^^^^^^^^^^^^^^^^
+
+In the example below, we will retrieve WETH/USDC offer data for a given time range on the network of the node connection.
+
+.. code-block:: python
+
+    weth_usdc_offers = client.get_offers(
+        pair_name="WETH/USDC",
+        book_side=OrderSide.NEUTRAL, # options are NEUTRAL, BUY, SELL
+        formatted=True, # by default is set to True, if set to False, raw data will be returned (with greater detail)
+        start_time=1688187600,
+        end_time=1690606800,
+    )
+
+Retrieving Trade Data
+^^^^^^^^^^^^^^^^^^^^^
+
+In the example below, we will access WETH/USDC trade data for a given time range on the network of the node connection.
+
+.. code-block:: python
+
+    weth_usdc_trades = client.get_trades(
+        pair_name="WETH/USDC",
+        book_side=OrderSide.NEUTRAL, # options are NEUTRAL, BUY, SELL
+        formatted=True, # by default is set to True, if set to False, raw data will be returned (with greater detail)
+        start_time=1688187600,
+        end_time=1690606800,
+    )

--- a/rubi/docs/source/rubi.contracts.types.rst
+++ b/rubi/docs/source/rubi.contracts.types.rst
@@ -1,13 +1,13 @@
-rubi.contracts.types package
-============================
+rubi.contracts.contract_types package
+=====================================
 
 Submodules
 ----------
 
-rubi.contracts.types.events module
-----------------------------------
+rubi.contracts.contract_types.events module
+-------------------------------------------
 
-.. automodule:: rubi.contracts.types.events
+.. automodule:: rubi.contracts.contract_types.events
    :members:
    :undoc-members:
    :show-inheritance:

--- a/rubi/docs/source/rubi.types.rst
+++ b/rubi/docs/source/rubi.types.rst
@@ -1,29 +1,29 @@
-rubi.types package
-==================
+rubi.rubicon_types package
+==========================
 
 Submodules
 ----------
 
-rubi.types.order module
------------------------
+rubi.rubicon_types.order module
+-------------------------------
 
-.. automodule:: rubi.types.order
+.. automodule:: rubi.rubicon_types.order
    :members:
    :undoc-members:
    :show-inheritance:
 
-rubi.types.orderbook module
----------------------------
+rubi.rubicon_types.orderbook module
+-----------------------------------
 
-.. automodule:: rubi.types.orderbook
+.. automodule:: rubi.rubicon_types.orderbook
    :members:
    :undoc-members:
    :show-inheritance:
 
-rubi.types.pair module
-----------------------
+rubi.rubicon_types.pair module
+------------------------------
 
-.. automodule:: rubi.types.pair
+.. automodule:: rubi.rubicon_types.pair
    :members:
    :undoc-members:
    :show-inheritance:

--- a/rubi/network_config/abitrum_goerli/network.yaml
+++ b/rubi/network_config/abitrum_goerli/network.yaml
@@ -4,6 +4,7 @@ currency: "ETH"
 rpc_url: "https://goerli-rollup.arbitrum.io/rpc"
 explorer_url: "https://goerli-rollup-explorer.arbitrum.io"
 market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Arbitrum_Goerli"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-arbitrum-goerli"
 
 rubicon:
  market:

--- a/rubi/network_config/arbitrum_one/abis/market.json
+++ b/rubi/network_config/arbitrum_one/abis/market.json
@@ -1,0 +1,1724 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "keeper",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "LogDelete",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "LogItemUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "LogMatch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "min_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "LogMinSell",
+    "type": "event"
+  },
+  {
+    "anonymous": true,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes4",
+        "name": "sig",
+        "type": "bytes4"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "guy",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "foo",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "bar",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "wad",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "fax",
+        "type": "bytes"
+      }
+    ],
+    "name": "LogNote",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "LogSetOwner",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "LogSortedOffer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "LogUnsortedOffer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "pair",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "pay_amt",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "buy_amt",
+        "type": "uint128"
+      }
+    ],
+    "name": "emitCancel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "pair",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      }
+    ],
+    "name": "emitDelete",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "taker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "feeTo",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "pair",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeAmt",
+        "type": "uint256"
+      }
+    ],
+    "name": "emitFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "pair",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "pay_amt",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "buy_amt",
+        "type": "uint128"
+      }
+    ],
+    "name": "emitOffer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "pair",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "taker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "take_amt",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "give_amt",
+        "type": "uint128"
+      }
+    ],
+    "name": "emitTake",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "AqueductAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "AqueductDistributionLive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "_best",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "_dust",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "_head",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "_near",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "_rank",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "next",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "prev",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "delb",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "_span",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "batchCancel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "payAmts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "payGems",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "buyAmts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "buyGems",
+        "type": "address[]"
+      }
+    ],
+    "name": "batchOffer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "payAmts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "payGems",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "buyAmts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "buyGems",
+        "type": "address[]"
+      }
+    ],
+    "name": "batchRequote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "buy",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max_fill_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "buyAllAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fill_amt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "buyEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isPay",
+        "type": "bool"
+      }
+    ],
+    "name": "calculateFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancel",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelBlacklistedOffer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "del_rank",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "dustId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "sell_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      }
+    ],
+    "name": "getBestOffer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getBetterOffer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      }
+    ],
+    "name": "getBuyAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fill_amt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      }
+    ],
+    "name": "getBuyAmountWithFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "approvalAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFeeBPS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFeeTo",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFirstUnsortedOffer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      }
+    ],
+    "name": "getMinSell",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNextUnsortedOffer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getOffer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "sell_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      }
+    ],
+    "name": "getOfferCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPayAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fill_amt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPayAmountWithFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "approvalAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRecipient",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTime",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "getWorseOffer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_feeTo",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "isActive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isClosed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "closed",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "isOfferSorted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "last_offer_id",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "makerFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "matchingEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pos",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "offer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pos",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "matching",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "offer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pos",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "rounding",
+        "type": "bool"
+      }
+    ],
+    "name": "offer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      }
+    ],
+    "name": "offer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "offer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "offers",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "timestamp",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "min_fill_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "sellAllAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fill_amt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newFeeBPS",
+        "type": "uint256"
+      }
+    ],
+    "name": "setFeeBPS",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newFeeTo",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeTo",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newMakerFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMakerFee",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "dust",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinSell",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner_",
+        "type": "address"
+      }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "requiresCheck",
+        "type": "bool"
+      }
+    ],
+    "name": "setTokenRequiresBlacklistCheck",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stop",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stopped",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "tokenRequiresBlacklistCheck",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/rubi/network_config/arbitrum_one/abis/router.json
+++ b/rubi/network_config/arbitrum_one/abis/router.json
@@ -1,0 +1,773 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "inputERC20",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "targetERC20",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "pair",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "inputAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "realizedFill",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "hurdleBuyAmtMin",
+        "type": "uint256"
+      }
+    ],
+    "name": "emitSwap",
+    "type": "event"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [],
+    "name": "RubiconMarketAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max_fill_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "buyAllAmountForETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fill",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max_fill_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "buyAllAmountWithETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fill",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelForETH",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "targetBathTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "checkClaimAllUserBonusTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "earnedAcrossPools",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "bathToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "depositWithETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "newShares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "quote",
+        "type": "address"
+      }
+    ],
+    "name": "getBestOfferAndInfo",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      }
+    ],
+    "name": "getBookDepth",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "depth",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bestOfferID",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "quote",
+        "type": "address"
+      }
+    ],
+    "name": "getBookFromPair",
+    "outputs": [
+      {
+        "internalType": "uint256[3][]",
+        "name": "asks",
+        "type": "uint256[3][]"
+      },
+      {
+        "internalType": "uint256[3][]",
+        "name": "bids",
+        "type": "uint256[3][]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "pay_amts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "buy_amt_mins",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address[][]",
+        "name": "routes",
+        "type": "address[][]"
+      }
+    ],
+    "name": "getExpectedMultiswapFill",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt_min",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "route",
+        "type": "address[]"
+      }
+    ],
+    "name": "getExpectedSwapFill",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "currentAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "baseToken",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      }
+    ],
+    "name": "getMakerBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "balanceInBook",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "quote",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      }
+    ],
+    "name": "getMakerBalanceInPair",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      }
+    ],
+    "name": "getOfferIDsFromPair",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "IDs",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      }
+    ],
+    "name": "getOffersFromPair",
+    "outputs": [
+      {
+        "internalType": "uint256[3][]",
+        "name": "offers",
+        "type": "uint256[3][]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[][]",
+        "name": "routes",
+        "type": "address[][]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "pay_amts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "buy_amts_min",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "multiswap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "pay_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pos",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "offerForETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "buy_gem",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pos",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "offerWithETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_theTrap",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "_weth",
+        "type": "address"
+      }
+    ],
+    "name": "startErUp",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "started",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt_min",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "route",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "swap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt_min",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "route",
+        "type": "address[]"
+      }
+    ],
+    "name": "swapForETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fill",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pay_amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buy_amt_min",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "route",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "swapWithETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "userNativeAssetOrders",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "wethAddress",
+    "outputs": [
+      {
+        "internalType": "address payable",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "bathToken",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawForETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "withdrawnWETH",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/rubi/network_config/arbitrum_one/network.yaml
+++ b/rubi/network_config/arbitrum_one/network.yaml
@@ -1,0 +1,22 @@
+name: "Arbitrum"
+chain_id: 42161
+currency: "ETH"
+rpc_url: "https://arb1.arbitrum.io/rpc"
+explorer_url: "https://arbiscan.io"
+market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Arbitrum_One"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-arbitrum-one"
+
+rubicon:
+ market:
+  address: "0xc715a30fde987637a082cf5f19c74648b67f2db8"
+ router:
+  address: "0x7b24e6f4dd84674696c2a5809c24154ec6ac7f03"
+
+token_addresses:
+ WETH: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+ USDC: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+ USDCe: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"
+ DAI: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+ USDT: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
+ WBTC: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+ ARB: "0x912CE59144191C1204E64559FE8253a0e49E6548"

--- a/rubi/network_config/optimism/network.yaml
+++ b/rubi/network_config/optimism/network.yaml
@@ -4,6 +4,7 @@ currency: "ETH"
 rpc_url: "https://mainnet.optimism.io"
 explorer_url: "https://optimistic.etherscan.io/"
 market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-optimism-mainnet"
 
 rubicon:
  market:

--- a/rubi/network_config/optimism_goerli/network.yaml
+++ b/rubi/network_config/optimism_goerli/network.yaml
@@ -4,6 +4,7 @@ currency: "ETH"
 rpc_url: "https://goerli.optimism.io"
 explorer_url: "https://goerli-explorer.optimism.io/"
 market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Goerli"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-optimism-goerli"
 
 rubicon:
  market:

--- a/rubi/network_config/polygon_mumbai/network.yaml
+++ b/rubi/network_config/polygon_mumbai/network.yaml
@@ -4,6 +4,7 @@ currency: "MATIC"
 rpc_url: "https://rpc-mumbai.maticvigil.com/"
 explorer_url: "https://mumbai.polygonscan.com/"
 market_data_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-polygon-mumbai"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-polygon-mumbai"
 
 rubicon:
  market:

--- a/rubi/pyproject.toml
+++ b/rubi/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rubi"
-version = "2.0.7b1"
+version = "2.1.6b2"
 description = "A python SDK for the Rubicon Protocol"
 authors = ["denver <denver@rubicon.finance>", "adam <adam@rubicon.finance>"]
 readme = "README.md"

--- a/rubi/rubi/client.py
+++ b/rubi/rubi/client.py
@@ -15,7 +15,12 @@ from rubi.contracts import (
     ERC20,
     TransactionReceipt,
     EmitFeeEvent,
+    EmitSwap,
+    EmitOfferEvent,
+    EmitTakeEvent,
+    EmitCancelEvent,
 )
+from rubi.data import MarketData
 from rubi.network import (
     Network,
 )
@@ -34,8 +39,6 @@ from rubi.rubicon_types import (
     NewCancelOrder,
     UpdateLimitOrder,
 )
-
-from rubi.data import MarketData
 
 
 class Client:
@@ -464,8 +467,8 @@ class Client:
 
         :param transaction: Transaction object containing the market order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed market order.
-        :rtype: str
+        :return: The transaction receipt of the executed market order.
+        :rtype: TransactionReceipt
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -477,7 +480,7 @@ class Client:
 
         match order.order_side:
             case OrderSide.BUY:
-                return self.market.buy_all_amount(
+                transaction_receipt = self.market.buy_all_amount(
                     buy_gem=pair.base_asset.address,
                     buy_amt=pair.base_asset.to_integer(order.size),
                     pay_gem=pair.quote_asset.address,
@@ -487,7 +490,7 @@ class Client:
                     **transaction.args(),
                 )
             case OrderSide.SELL:
-                return self.market.sell_all_amount(
+                transaction_receipt = self.market.sell_all_amount(
                     pay_gem=pair.base_asset.address,
                     pay_amt=pair.base_asset.to_integer(order.size),
                     buy_gem=pair.quote_asset.address,
@@ -496,6 +499,10 @@ class Client:
                     ),
                     **transaction.args(),
                 )
+            case _:
+                raise Exception("OrderSide must be BUY or SELL")
+
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
 
     def place_limit_order(self, transaction: Transaction) -> TransactionReceipt:
         """Place a limit order transaction by executing the specified transaction object. The transaction object should
@@ -503,8 +510,8 @@ class Client:
 
         :param transaction: Transaction object containing the limit order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed limit order.
-        :rtype: str
+        :return: The transaction receipt of the executed limit order.
+        :rtype: TransactionReceipt
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -516,7 +523,7 @@ class Client:
 
         match order.order_side:
             case OrderSide.BUY:
-                return self.market.offer(
+                transaction_receipt = self.market.offer(
                     pay_amt=pair.quote_asset.to_integer(order.price * order.size),
                     pay_gem=pair.quote_asset.address,
                     buy_amt=pair.base_asset.to_integer(order.size),
@@ -524,13 +531,17 @@ class Client:
                     **transaction.args(),
                 )
             case OrderSide.SELL:
-                return self.market.offer(
+                transaction_receipt = self.market.offer(
                     pay_amt=pair.base_asset.to_integer(order.size),
                     pay_gem=pair.base_asset.address,
                     buy_amt=pair.quote_asset.to_integer(order.price * order.size),
                     buy_gem=pair.quote_asset.address,
                     **transaction.args(),
                 )
+            case _:
+                raise Exception("OrderSide must be BUY or SELL")
+
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
 
     def cancel_limit_order(self, transaction: Transaction) -> TransactionReceipt:
         """Place a limit order cancel transaction by executing the specified transaction object. The transaction object
@@ -538,8 +549,8 @@ class Client:
 
         :param transaction: Transaction object containing the cancel order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed cancel order.
-        :rtype: str
+        :return: The transaction receipt of the executed cancel order.
+        :rtype: TransactionReceipt
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -547,15 +558,19 @@ class Client:
 
         order: NewCancelOrder = transaction.orders[0]  # noqa
 
-        return self.market.cancel(id=order.order_id, **transaction.args())
+        transaction_receipt = self.market.cancel(
+            id=order.order_id, **transaction.args()
+        )
+
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
 
     def batch_place_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Place multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit orders.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit orders.
-        :rtype: str
+        :return: The transaction receipt of the executed batch limit orders.
+        :rtype: TransactionReceipt
         """
         pay_amts = []
         pay_gems = []
@@ -582,7 +597,7 @@ class Client:
                     )
                     buy_gems.append(pair.quote_asset.address)
 
-        return self.market.batch_offer(
+        transaction_receipt = self.market.batch_offer(
             pay_amts=pay_amts,
             pay_gems=pay_gems,
             buy_amts=buy_amts,
@@ -590,13 +605,15 @@ class Client:
             **transaction.args(),
         )
 
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
+
     def batch_update_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Update multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit order updates.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit order updates.
-        :rtype: str
+        :return: The transaction receipt of the executed batch limit order updates.
+        :rtype: TransactionReceipt
         """
         order_ids = []
         pay_amts = []
@@ -626,7 +643,7 @@ class Client:
                     )
                     buy_gems.append(pair.quote_asset.address)
 
-        return self.market.batch_requote(
+        transaction_receipt = self.market.batch_requote(
             ids=order_ids,
             pay_amts=pay_amts,
             pay_gems=pay_gems,
@@ -635,13 +652,15 @@ class Client:
             **transaction.args(),
         )
 
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
+
     def batch_cancel_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Cancel multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit order cancellations.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit order cancellations.
-        :rtype: str
+        :return: The transaction receipt of the executed batch limit order cancellations.
+        :rtype: TransactionReceipt
         """
         order_ids = []
 
@@ -650,42 +669,84 @@ class Client:
 
             order_ids.append(order.order_id)
 
-        return self.market.batch_cancel(ids=order_ids, **transaction.args())
+        transaction_receipt = self.market.batch_cancel(
+            ids=order_ids, **transaction.args()
+        )
+
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
 
     ######################################################################
-    # data methods (raw data) TODO: once we have cleanly formatted data functions, we can switch to only exposing those
+    # data methods
     ######################################################################
 
+    # TODO: i would like to remove pay_gem and buy_gem and follow the same pattern as the get_trades method but do not want to cause breaking changes
     def get_offers(
         self,
-        maker: Optional[str] = None,
-        from_address: Optional[str] = None,
+        first: int = 10000000,  # TODO: decide on a default value
+        order_by: str = "timestamp",
+        order_direction: str = "desc",
+        formatted: bool = True,
+        book_side: OrderSide = OrderSide.NEUTRAL,
+        maker: Optional[Union[ChecksumAddress, str]] = None,
+        from_address: Optional[Union[ChecksumAddress, str]] = None,
         pair_name: Optional[str] = None,
-        book_side: Optional[OrderSide] = None,
-        pay_gem: Optional[str] = None,
-        buy_gem: Optional[str] = None,
+        pay_gem: Optional[Union[ChecksumAddress, str]] = None,
+        buy_gem: Optional[Union[ChecksumAddress, str]] = None,
         open: Optional[bool] = None,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
-        first: Optional[int] = 1000,
-        order_by: Optional[str] = "timestamp",
-        order_direction: Optional[str] = "desc",
-        formatted: Optional[bool] = True,
     ) -> pd.DataFrame:
         df = self.market_data.get_offers(
-            maker,
-            from_address,
-            pair_name,
-            book_side,
-            pay_gem,
-            buy_gem,
-            open,
-            start_time,
-            end_time,
-            first,
-            order_by,
-            order_direction,
-            formatted,
+            maker=maker,
+            from_address=from_address,
+            pair_name=pair_name,
+            book_side=book_side,
+            pay_gem=pay_gem,
+            buy_gem=buy_gem,
+            open=open,
+            start_time=start_time,
+            end_time=end_time,
+            first=first,
+            order_by=order_by,
+            order_direction=order_direction,
+            formatted=formatted,
+        )
+        return df
+
+    def get_trades(
+        self,
+        first: int = 10000000,  # TODO: decide on a default value
+        order_by: str = "timestamp",
+        order_direction: str = "desc",
+        formatted: bool = True,
+        book_side: OrderSide = OrderSide.NEUTRAL,
+        taker: Optional[Union[ChecksumAddress, str]] = None,
+        from_address: Optional[Union[ChecksumAddress, str]] = None,
+        pair_name: Optional[str] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+    ) -> pd.DataFrame:
+        # handle the pair_name parameter
+        if pair_name:
+            base, quote = pair_name.split("/")
+            base_asset = ERC20.from_network(name=base, network=self.network).address
+            quote_asset = ERC20.from_network(name=quote, network=self.network).address
+        else:
+            base_asset = None
+            quote_asset = None
+
+        df = self.market_data.get_trades(
+            first=first,
+            order_by=order_by,
+            order_direction=order_direction,
+            book_side=book_side,
+            formatted=formatted,
+            taker=taker,
+            from_address=from_address,
+            take_gem=base_asset,
+            give_gem=quote_asset,
+            start_time=start_time,
+            end_time=end_time,
         )
         return df
 
@@ -728,3 +789,49 @@ class Client:
     @staticmethod
     def _check_allowance(pair: Pair, order: BaseNewOrder):
         pass
+
+    def _handle_transaction_receipt_raw_events(
+        self, transaction_receipt: TransactionReceipt
+    ) -> TransactionReceipt:
+        """
+        Transforms the raw transaction receipt events to human-readable events
+
+        :param transaction_receipt:
+        :type transaction_receipt: TransactionReceipt
+        :return: The transaction receipt with human-readable events populated
+        :rtype: TransactionReceipt
+        """
+        events: List[OrderEvent] = []
+        for raw_event in transaction_receipt.raw_events:
+            if (
+                isinstance(raw_event, EmitFeeEvent)
+                or isinstance(raw_event, EmitSwap)
+                or isinstance(raw_event, Dict)
+            ):
+                # TODO: handle these events correctly
+                continue
+            else:
+                raw_event: Union[EmitOfferEvent, EmitTakeEvent, EmitCancelEvent]
+
+                event_pair = None
+                for pair in self._pairs.values():
+                    if (
+                        pair.ask_identifier == raw_event.pair
+                        or pair.bid_identifier == raw_event.pair
+                    ):
+                        event_pair = pair
+                        break
+
+                if not event_pair:
+                    # We don't have a pair setup to correctly decode this event
+                    continue
+
+                events.append(
+                    OrderEvent.from_event(
+                        pair=event_pair, event=raw_event, wallet=self.wallet
+                    )
+                )
+
+        transaction_receipt.set_events(events=events)
+
+        return transaction_receipt

--- a/rubi/rubi/contracts/base_contract.py
+++ b/rubi/rubi/contracts/base_contract.py
@@ -1,18 +1,34 @@
 import logging as log
 import time
+from enum import Enum
 from threading import Thread
 from time import sleep
-from typing import Optional, Callable, Type, Dict, Any
+from typing import Optional, Callable, Type, Dict, Any, List
 
 from eth_account.datastructures import SignedTransaction
 from eth_typing import ChecksumAddress
+from hexbytes import HexBytes
 from web3 import Web3
 from web3._utils.filters import LogFilter  # noqa
 from web3.contract import Contract
-from web3.contract.contract import ContractFunction
-from web3.types import ABI, Nonce
+from web3.contract.contract import (
+    ContractFunction,
+)  # TODO: figure out why jupyter notebook is complaining about this
+from web3.logs import DISCARD
+from web3.types import ABI, Nonce, TxReceipt, EventData
 
 from rubi.contracts.contract_types import BaseEvent, TransactionReceipt
+
+
+class ContractType(Enum):
+    """Enum to distinguish the type of contract instantiated
+
+    Should only be used internally
+    """
+
+    RUBICON_MARKET = "RUBICON_MARKET"
+    RUBICON_ROUTER = "RUBICON_ROUTER"
+    ERC20 = "ERC20"
 
 
 class BaseContract:
@@ -23,6 +39,8 @@ class BaseContract:
     :type w3: Web3
     :param contract: Contract instance
     :type contract: Contract
+    :param contract_type: the type of contract
+    :type contract_type: ContractType
     :param wallet: a wallet address of the signer (optional, default is None)
     :type wallet: Optional[ChecksumAddress]
     :param key: the private key of the signer (optional, default is None)
@@ -33,6 +51,7 @@ class BaseContract:
         self,
         w3: Web3,
         contract: Contract,
+        contract_type: ContractType,
         wallet: Optional[ChecksumAddress] = None,
         key: Optional[str] = None,
     ):
@@ -44,6 +63,7 @@ class BaseContract:
 
         self.contract = contract
         self.address = contract.address
+        self.contract_type = contract_type
         self.w3 = w3
         self.chain_id = self.w3.eth.chain_id
 
@@ -63,6 +83,7 @@ class BaseContract:
         w3: Web3,
         address: ChecksumAddress,
         contract_abi: ABI,
+        contract_type: ContractType,
         wallet: Optional[ChecksumAddress] = None,
         key: Optional[str] = None,
     ) -> "BaseContract":
@@ -74,6 +95,8 @@ class BaseContract:
         :type address: ChecksumAddress
         :param contract_abi: The ABI of the contract.
         :type contract_abi: ABI
+        :param contract_type: The type of contract we are instantiating.
+        :type contract_type: ContractType
         :param wallet: The wallet address to use for interacting with the contract (optional, default is None).
         :type wallet: Optional[ChecksumAddress]
         :param key: The private key of the wallet (optional, default is None).
@@ -84,7 +107,27 @@ class BaseContract:
 
         contract = w3.eth.contract(address=address, abi=contract_abi)
 
-        return cls(w3=w3, contract=contract, wallet=wallet, key=key)
+        return cls(
+            w3=w3,
+            contract=contract,
+            contract_type=contract_type,
+            wallet=wallet,
+            key=key,
+        )
+
+    ######################################################################
+    # useful methods
+    ######################################################################
+
+    def get_transaction_receipt(self, transaction_hash: str) -> TransactionReceipt:
+        """Get a transaction receipt for the give transaction_hash.
+
+        :param transaction_hash: The transaction hash.
+        :type transaction_hash: str
+        :return: A TransactionReceipt for the transaction hash.
+        :rtype: TransactionReceipt
+        """
+        return self._wait_for_transaction_receipt(transaction_hash=transaction_hash)
 
     ######################################################################
     # event listeners
@@ -283,7 +326,9 @@ class BaseContract:
         return {key: value for key, value in transaction.items() if value is not None}
 
     def _wait_for_transaction_receipt(
-        self, transaction: SignedTransaction
+        self,
+        transaction: Optional[SignedTransaction] = None,
+        transaction_hash: Optional[str] = None,
     ) -> TransactionReceipt:
         """Wait for the transaction receipt and check if the transaction was successful.
 
@@ -291,10 +336,62 @@ class BaseContract:
         :type transaction: SignedTransaction
         """
 
+        if transaction:
+            tx_receipt = self.w3.eth.wait_for_transaction_receipt(transaction.hash)
+        elif transaction_hash:
+            tx_receipt = self.w3.eth.wait_for_transaction_receipt(
+                HexBytes(transaction_hash)
+            )
+        else:
+            raise Exception("Provide either a transaction or a transaction_hash")
+
+        raw_events = self._process_receipt_logs_into_raw_events(receipt=tx_receipt)
+
         result = TransactionReceipt.from_tx_receipt(
-            tx_receipt=self.w3.eth.wait_for_transaction_receipt(transaction.hash)
+            tx_receipt=tx_receipt, raw_events=raw_events
         )
 
         log.debug(f"RECEIVED RESULT, timestamp: {time.time_ns()}")
 
         return result
+
+    def _process_receipt_logs_into_raw_events(
+        self, receipt: TxReceipt
+    ) -> List[BaseEvent | EventData]:
+        """
+        Processes the logs of a given transaction receipt and returns a list of events associated with the transaction.
+
+        :param receipt:
+        :type receipt: TxReceipt
+        :return: The list of events associated with the given transaction receipt
+        :rtype: List[BaseEvent]
+        """
+        match self.contract_type:
+            case ContractType.RUBICON_MARKET:
+                event_names = ["emitTake", "emitOffer", "emitCancel"]
+            case ContractType.RUBICON_ROUTER:
+                event_names = ["emitSwap"]
+            case ContractType.ERC20:
+                event_names = ["Approval", "Transfer"]
+            case _:
+                raise Exception("Unexpected ContractType")
+
+        raw_events = []
+        for event_name in event_names:
+            transaction_events_data = self.contract.events[
+                event_name
+            ]().process_receipt(receipt, DISCARD)
+
+            for event_data in transaction_events_data:
+                if self.contract_type == ContractType.ERC20:
+                    raw_events.append(event_data)
+
+                raw_events.append(
+                    BaseEvent.builder(
+                        name=event_name,
+                        block_number=event_data["blockNumber"],
+                        **event_data["args"],
+                    )
+                )
+
+        return raw_events

--- a/rubi/rubi/contracts/contract_types/events.py
+++ b/rubi/rubi/contracts/contract_types/events.py
@@ -27,6 +27,20 @@ class BaseEvent(ABC):
         self.block_number = block_number
 
     @staticmethod
+    def builder(
+        name: str, **kwargs
+    ) -> Union["EmitOfferEvent", "EmitTakeEvent", "EmitCancelEvent", "EmitSwap"]:
+        match name:
+            case "emitOffer":
+                return EmitOfferEvent(**kwargs)
+            case "emitTake":
+                return EmitTakeEvent(**kwargs)
+            case "emitCancel":
+                return EmitCancelEvent(**kwargs)
+            case "emitSwap":
+                return EmitSwap(**kwargs)
+
+    @staticmethod
     @abstractmethod
     def get_event_contract(
         market: _RubiconMarket, router: _RubiconRouter
@@ -147,7 +161,7 @@ class EmitOfferEvent(BaseMarketEvent):
         buy_gem: ChecksumAddress,
         pay_amt: int,
         buy_amt: int,
-        **args
+        **args,
     ):
         """Initialize an EmitOfferEvent instance.
 
@@ -199,7 +213,7 @@ class EmitTakeEvent(BaseMarketEvent):
         buy_gem: ChecksumAddress,
         take_amt: int,
         give_amt: int,
-        **args
+        **args,
     ):
         """Initialize an EmitTakeEvent instance.
 
@@ -258,7 +272,7 @@ class EmitCancelEvent(BaseMarketEvent):
         buy_gem: ChecksumAddress,
         pay_amt: int,
         buy_amt: int,
-        **args
+        **args,
     ):
         """Initialize an EmitCancelEvent instance.
 
@@ -309,7 +323,7 @@ class EmitFeeEvent(BaseMarketEvent):
         feeTo: ChecksumAddress,
         asset: ChecksumAddress,
         feeAmt: int,
-        **args
+        **args,
     ):
         """Initialize an EmitFeeEvent instance.
 
@@ -399,7 +413,7 @@ class EmitSwap(BaseEvent):
         inputAmount: int,
         realizedFill: int,
         hurdleBuyAmtMin: int,
-        **args
+        **args,
     ):
         """Initialize an EmitSwap instance.
 

--- a/rubi/rubi/contracts/erc20.py
+++ b/rubi/rubi/contracts/erc20.py
@@ -8,7 +8,7 @@ from web3 import Web3
 from web3.contract import Contract
 from web3.types import ABI
 
-from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.base_contract import BaseContract, ContractType
 from rubi.contracts.contract_types import TransactionReceipt
 from rubi.network import Network
 
@@ -31,11 +31,18 @@ class ERC20(BaseContract):
         self,
         w3: Web3,
         contract: Contract,
+        contract_type: ContractType = ContractType.ERC20,
         wallet: Optional[ChecksumAddress] = None,
         key: Optional[str] = None,
     ):
         """constructor method"""
-        super().__init__(w3=w3, contract=contract, wallet=wallet, key=key)
+        super().__init__(
+            w3=w3,
+            contract=contract,
+            contract_type=ContractType.ERC20,
+            wallet=wallet,
+            key=key,
+        )
 
         self.name: str = self.name()
         self.symbol: str = self.symbol()
@@ -87,6 +94,7 @@ class ERC20(BaseContract):
             w3=network.w3,
             address=network.token_addresses[name],
             contract_abi=abi,
+            contract_type=ContractType.ERC20,
             wallet=wallet,
             key=key,
         )
@@ -127,7 +135,12 @@ class ERC20(BaseContract):
             )
 
         return cls.from_address_and_abi(
-            w3=w3, address=address, contract_abi=abi, wallet=wallet, key=key
+            w3=w3,
+            address=address,
+            contract_abi=abi,
+            contract_type=ContractType.ERC20,
+            wallet=wallet,
+            key=key,
         )
 
     ######################################################################

--- a/rubi/rubi/contracts/market.py
+++ b/rubi/rubi/contracts/market.py
@@ -4,7 +4,7 @@ from eth_typing import ChecksumAddress
 from web3 import Web3
 from web3.contract import Contract
 
-from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.base_contract import BaseContract, ContractType
 from rubi.contracts.contract_types import TransactionReceipt
 from rubi.network import Network
 
@@ -27,11 +27,18 @@ class RubiconMarket(BaseContract):
         self,
         w3: Web3,
         contract: Contract,
+        contract_type: ContractType = ContractType.RUBICON_MARKET,
         wallet: Optional[ChecksumAddress] = None,
         key: Optional[str] = None,
     ) -> None:
         """constructor method"""
-        super().__init__(w3=w3, contract=contract, wallet=wallet, key=key)
+        super().__init__(
+            w3=w3,
+            contract=contract,
+            contract_type=ContractType.RUBICON_MARKET,
+            wallet=wallet,
+            key=key,
+        )
 
     @classmethod
     def from_network(
@@ -55,6 +62,7 @@ class RubiconMarket(BaseContract):
             w3=network.w3,
             address=network.rubicon.market.address,
             contract_abi=network.rubicon.market.abi,
+            contract_type=ContractType.RUBICON_MARKET,
             wallet=wallet,
             key=key,
         )
@@ -220,7 +228,7 @@ class RubiconMarket(BaseContract):
         buy_amt: int,
         buy_gem: ChecksumAddress,
         pos: int = 0,
-        rounding: bool = True,
+        rounding: bool = False,
         owner: Optional[ChecksumAddress] = None,
         recipient: Optional[ChecksumAddress] = None,
         nonce: Optional[int] = None,
@@ -241,7 +249,7 @@ class RubiconMarket(BaseContract):
         :param pos: position of the offer in the linked list, default to 0 unless the maker knows the position they want
             to insert the offer at
         :type pos: int
-        :param rounding: add rounding to match "close enough" orders, defaults to True
+        :param rounding: add rounding to match "close enough" orders, defaults to False
         :type: rounding: bool
         :param owner: the owner of the offer, defaults to the wallet that was provided in instantiating this class.
             (optional, default is None)

--- a/rubi/rubi/contracts/router.py
+++ b/rubi/rubi/contracts/router.py
@@ -4,7 +4,7 @@ from eth_typing import ChecksumAddress
 from web3 import Web3
 from web3.contract import Contract
 
-from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.base_contract import BaseContract, ContractType
 from rubi.contracts.contract_types import TransactionReceipt
 from rubi.network import Network
 
@@ -27,11 +27,18 @@ class RubiconRouter(BaseContract):
         self,
         w3: Web3,
         contract: Contract,
+        contract_type: ContractType = ContractType.RUBICON_ROUTER,
         wallet: Optional[ChecksumAddress] = None,
         key: Optional[str] = None,
     ) -> None:
         """constructor method"""
-        super().__init__(w3=w3, contract=contract, wallet=wallet, key=key)
+        super().__init__(
+            w3=w3,
+            contract=contract,
+            contract_type=ContractType.RUBICON_ROUTER,
+            wallet=wallet,
+            key=key,
+        )
 
     @classmethod
     def from_network(
@@ -55,6 +62,7 @@ class RubiconRouter(BaseContract):
             w3=network.w3,
             address=network.rubicon.router.address,
             contract_abi=network.rubicon.router.abi,
+            contract_type=ContractType.RUBICON_ROUTER,
             wallet=wallet,
             key=key,
         )

--- a/rubi/rubi/data/market.py
+++ b/rubi/rubi/data/market.py
@@ -237,3 +237,75 @@ class MarketData:
             df = self.offer_query.query_offers(fields)
 
             return df
+            
+    def get_limit_orders(
+            self, 
+            maker: Optional[str] = None,
+            from_address: Optional[str] = None,
+            pair_name: Optional[str] = None,
+            book_side: Optional[OrderSide] = None,
+            pay_gem: Optional[str] = None,  # TODO: maybe we should allow the user to pass in an address here?
+            buy_gem: Optional[str] = None,  # TODO: maybe we should allow the user to pass in an address here?
+            open: Optional[bool] = None,
+            start_time: Optional[int] = None,
+            end_time: Optional[int] = None,
+            first: Optional[int] = 1000,
+            order_by: Optional[str] = 'timestamp',
+            order_direction: Optional[str] = 'desc'
+        ): # -> List[LimitOrder]: # TODO: determine how we want to return this data
+            
+            # handle the pair_name parameter
+            if pair_name:
+                base, quote = pair_name.split("/")
+                base_asset = ERC20.from_network(name=base, network=self.network)
+                quote_asset = ERC20.from_network(name=quote, network=self.network)
+
+            # handle the book_side parameter
+            if book_side and pair_name:
+
+                match book_side:
+                    case OrderSide.BUY:
+                        buy_query = self.offer_query.offers_query(order_by, order_direction, first, maker, from_address,
+                                                                pay_gem=quote_asset.address, buy_gem=base_asset.address,
+                                                                open=open, start_time=start_time, end_time=end_time)
+                        buy_fields = self.offer_query.offers_fields(buy_query, False)
+                        buy_df = self.offer_query.query_offers(buy_fields, False)
+                        buy_df['side'] = 'buy'  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
+
+                        bids = self.offer_query.dataframe_to_limit_orders(buy_df, pair_name)
+
+                        return bids
+
+                    case OrderSide.SELL:
+                        sell_query = self.offer_query.offers_query(order_by, order_direction, first, maker, from_address,
+                                                                pay_gem=base_asset.address, buy_gem=quote_asset.address,
+                                                                open=open, start_time=start_time, end_time=end_time)
+                        sell_fields = self.offer_query.offers_fields(sell_query, False)
+                        sell_df = self.offer_query.query_offers(sell_fields, False)
+                        sell_df['side'] = 'sell'  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
+
+                        asks = self.offer_query.dataframe_to_limit_orders(sell_df, pair_name)
+
+                        return asks
+
+                    case OrderSide.NEUTRAL:
+                        buy_query = self.offer_query.offers_query(order_by, order_direction, first, maker, from_address,
+                                                                pay_gem=quote_asset.address, buy_gem=base_asset.address,
+                                                                open=open, start_time=start_time, end_time=end_time)
+                        buy_fields = self.offer_query.offers_fields(buy_query, False)
+                        buy_df = self.offer_query.query_offers(buy_fields, False)
+                        buy_df['side'] = 'buy'  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
+
+                        sell_query = self.offer_query.offers_query(order_by, order_direction, first, maker, from_address,
+                                                                pay_gem=base_asset.address, buy_gem=quote_asset.address,
+                                                                open=open, start_time=start_time, end_time=end_time)
+                        sell_fields = self.offer_query.offers_fields(sell_query, False)
+                        sell_df = self.offer_query.query_offers(sell_fields, False)
+                        sell_df['side'] = 'sell'  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
+
+                        bids = self.offer_query.dataframe_to_limit_orders(buy_df, pair_name)
+                        asks = self.offer_query.dataframe_to_limit_orders(sell_df, pair_name)
+
+                        return [bids, asks]
+                    
+        

--- a/rubi/rubi/data/market.py
+++ b/rubi/rubi/data/market.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, Union
 
 import pandas as pd
 from eth_typing import ChecksumAddress
@@ -13,6 +13,7 @@ from rubi.network import (
 from rubi.rubicon_types import (
     OrderSide,
     OrderQuery,
+    TradeQuery,
 )
 
 
@@ -33,27 +34,39 @@ class MarketData:
         self,
         subgrounds: Subgrounds,
         subgraph_url: str,
+        subgraph_fallback_url: str,
         network: Optional[Network] = None,
         network_tokens: Optional[Dict[ChecksumAddress, ERC20]] = None,
     ):
         """constructor method"""
         self.sg = subgrounds
         self.subgraph_url = subgraph_url
+        self.subgraph_fallback_url = subgraph_fallback_url
         self.network = network  # type: Network | None
         self.tokens = network_tokens  # type: Dict[ChecksumAddress, ERC20] | None
 
         # initialize the subgraph
-        try:
-            self.data = self.sg.load_subgraph(self.subgraph_url)
-            # TODO: we should add a check here to guarantee the schema matches what we expect to be receiving
-        except:
-            # TODO: not sure exactly what error we should be throwing here, this is if the url does not work
-            raise ValueError(
-                f"subgraph_url: {subgraph_url} failed when attempting to load."
-            )
+        for attempt in range(3):
+            try:
+                self.data = self.sg.load_subgraph(
+                    self.subgraph_url
+                )  # TODO: we should add a check here to guarantee the schema matches what we expect to be receiving
+                break
+            except Exception as e:
+                if attempt < 2:
+                    continue
+                else:
+                    try:
+                        self.data = self.sg.load_subgraph(self.subgraph_fallback_url)
+                        break
+                    except:
+                        raise ValueError(
+                            f"Both subgraph_url: {self.subgraph_url} and fallback_url: {self.subgraph_fallback_url} failed when attempting to load. Error: {str(e)}"
+                        )
 
         # Initialize the query classes
         self.offer_query = OrderQuery(self.sg, self.data, self.network, self.tokens)
+        self.trade_query = TradeQuery(self.sg, self.data, self.network, self.tokens)
 
     @classmethod
     def from_network_with_tokens(
@@ -63,6 +76,7 @@ class MarketData:
         return cls(
             subgrounds=network.subgrounds,
             subgraph_url=network.market_data_url,
+            subgraph_fallback_url=network.market_data_fallback_url,
             network=network,
             network_tokens=network_tokens,
         )
@@ -74,23 +88,19 @@ class MarketData:
     # TODO: refactor using a decorator to handle the parameter validation
     def get_offers(
         self,
-        maker: Optional[str] = None,
-        from_address: Optional[str] = None,
+        first: int = 1000,
+        order_by: str = "timestamp",
+        order_direction: str = "desc",
+        formatted: bool = False,
+        book_side: OrderSide = OrderSide.NEUTRAL,
+        maker: Optional[Union[ChecksumAddress, str]] = None,
+        from_address: Optional[Union[ChecksumAddress, str]] = None,
         pair_name: Optional[str] = None,
-        book_side: Optional[OrderSide] = None,
-        pay_gem: Optional[
-            str
-        ] = None,  # TODO: maybe we should allow the user to pass in an address here?
-        buy_gem: Optional[
-            str
-        ] = None,  # TODO: maybe we should allow the user to pass in an address here?
+        pay_gem: Optional[Union[ChecksumAddress, str]] = None,
+        buy_gem: Optional[Union[ChecksumAddress, str]] = None,
         open: Optional[bool] = None,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
-        first: Optional[int] = 1000,
-        order_by: Optional[str] = "timestamp",
-        order_direction: Optional[str] = "desc",
-        formatted: Optional[bool] = False,
     ) -> pd.DataFrame:
         """Returns a dataframe of offers placed on the market contract, with the option to pass in filters.
 
@@ -133,7 +143,9 @@ class MarketData:
             quote_asset = ERC20.from_network(name=quote, network=self.network)
 
         # handle the book_side parameter
-        if book_side and pair_name:
+        if (
+            book_side and pair_name
+        ):  # TODO: we need to handle the case where neither of these are passed
             match book_side:
                 case OrderSide.BUY:
                     buy_query = self.offer_query.offers_query(
@@ -235,8 +247,151 @@ class MarketData:
             )
             fields = self.offer_query.offers_fields(query)
             df = self.offer_query.query_offers(fields)
+            df["side"] = "N/A"
 
             return df
+
+    # TODO: add an optional filter by maker when
+    def get_trades(
+        self,
+        first: int = 1000,  # TODO: maybe this should be a large number by default?
+        order_by: str = "timestamp",
+        order_direction: str = "desc",
+        formatted: bool = False,
+        book_side: OrderSide = OrderSide.NEUTRAL,
+        taker: Optional[Union[ChecksumAddress, str]] = None,
+        from_address: Optional[Union[ChecksumAddress, str]] = None,
+        take_gem: Optional[Union[ChecksumAddress, str]] = None,
+        give_gem: Optional[Union[ChecksumAddress, str]] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+    ) -> pd.DataFrame:
+        """Returns a dataframe of trades that have occurred on the market contract, with the option to pass in filters.
+
+        :param taker: the address of the taker of the trade
+        :type taker: str
+        :param from_address: the address that originated the transaction that created the trade
+        :type from_address: str
+        :param book_side: the side of the order book that the trade occurred on (defaults to neutral, options: buy, sell, neutral)
+        :type book_side: OrderSide
+        :param take_gem: the address of the token that the taker received
+        :type take_gem: str
+        :param give_gem: the address of the token that the taker gave
+        :type give_gem: str
+        :param start_time: the timestamp of the earliest trade to return
+        :type start_time: int
+        :param end_time: the timestamp of the latest trade to return
+        :type end_time: int
+        :param first: the number of trades to return
+        :type first: int
+        :param order_by: the field to order the trades by (default: timestamp, options: timestamp) TODO: expand this list
+        :type order_by: str
+        :param order_direction: the direction to order the trades by (default: desc, options: asc, desc)
+        :type order_direction: str
+        :param formatted: whether or not to return the formatted fields (default: False, requires a network object to be passed)
+        :type formatted: bool
+        :return: a dataframe of trades that have occurred on the market contract
+        :rtype: pd.DataFrame
+        """
+
+        # if we want formatted fields, make sure we have a network object
+        if formatted and not self.network:
+            raise ValueError(
+                "Cannot return formatted fields without a network object initialized on the class."
+            )
+
+        if take_gem is None and give_gem is None:
+            all_trades_query = self.trade_query.trades_query(
+                order_by,
+                order_direction,
+                first,
+                taker,
+                from_address,
+                take_gem=take_gem,
+                give_gem=give_gem,
+                start_time=start_time,
+                end_time=end_time,
+            )
+            all_trades_fields = self.trade_query.trades_fields(
+                all_trades_query, formatted
+            )
+            all_trades_df = self.trade_query.query_trades(all_trades_fields, formatted)
+            all_trades_df["side"] = "N/A"
+
+            return all_trades_df
+
+        else:
+            match book_side:
+                case OrderSide.BUY:
+                    buy_query = self.trade_query.trades_query(
+                        order_by,
+                        order_direction,
+                        first,
+                        taker,
+                        from_address,
+                        take_gem=take_gem,
+                        give_gem=give_gem,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    buy_fields = self.trade_query.trades_fields(buy_query, formatted)
+                    buy_df = self.trade_query.query_trades(buy_fields, formatted)
+                    buy_df["side"] = "buy"
+
+                    return buy_df
+
+                case OrderSide.SELL:
+                    sell_query = self.trade_query.trades_query(
+                        order_by,
+                        order_direction,
+                        first,
+                        taker,
+                        from_address,
+                        take_gem=give_gem,
+                        give_gem=take_gem,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    sell_fields = self.trade_query.trades_fields(sell_query, formatted)
+                    sell_df = self.trade_query.query_trades(sell_fields, formatted)
+                    sell_df["side"] = "sell"
+
+                    return sell_df
+
+                case OrderSide.NEUTRAL:
+                    buy_query = self.trade_query.trades_query(
+                        order_by,
+                        order_direction,
+                        first,  # TODO: decide if we only want to pass half the values here
+                        taker,
+                        from_address,
+                        take_gem=take_gem,
+                        give_gem=give_gem,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    buy_fields = self.trade_query.trades_fields(buy_query, formatted)
+                    buy_df = self.trade_query.query_trades(buy_fields, formatted)
+                    buy_df["side"] = "buy"
+
+                    sell_query = self.trade_query.trades_query(
+                        order_by,
+                        order_direction,
+                        first,
+                        taker,
+                        from_address,
+                        take_gem=give_gem,
+                        give_gem=take_gem,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    sell_fields = self.trade_query.trades_fields(sell_query, formatted)
+                    sell_df = self.trade_query.query_trades(sell_fields, formatted)
+                    sell_df["side"] = "sell"
+
+                    return pd.concat([buy_df, sell_df]).reset_index(
+                        drop=True
+                    )  # TODO: decide what we want to do here, maybe we just return both dataframes?
 
     def get_limit_orders(
         self,

--- a/rubi/rubi/data/market.py
+++ b/rubi/rubi/data/market.py
@@ -237,75 +237,123 @@ class MarketData:
             df = self.offer_query.query_offers(fields)
 
             return df
-            
+
     def get_limit_orders(
-            self, 
-            maker: Optional[str] = None,
-            from_address: Optional[str] = None,
-            pair_name: Optional[str] = None,
-            book_side: Optional[OrderSide] = None,
-            pay_gem: Optional[str] = None,  # TODO: maybe we should allow the user to pass in an address here?
-            buy_gem: Optional[str] = None,  # TODO: maybe we should allow the user to pass in an address here?
-            open: Optional[bool] = None,
-            start_time: Optional[int] = None,
-            end_time: Optional[int] = None,
-            first: Optional[int] = 1000,
-            order_by: Optional[str] = 'timestamp',
-            order_direction: Optional[str] = 'desc'
-        ): # -> List[LimitOrder]: # TODO: determine how we want to return this data
-            
-            # handle the pair_name parameter
-            if pair_name:
-                base, quote = pair_name.split("/")
-                base_asset = ERC20.from_network(name=base, network=self.network)
-                quote_asset = ERC20.from_network(name=quote, network=self.network)
+        self,
+        maker: Optional[str] = None,
+        from_address: Optional[str] = None,
+        pair_name: Optional[str] = None,
+        book_side: Optional[OrderSide] = None,
+        pay_gem: Optional[
+            str
+        ] = None,  # TODO: maybe we should allow the user to pass in an address here?
+        buy_gem: Optional[
+            str
+        ] = None,  # TODO: maybe we should allow the user to pass in an address here?
+        open: Optional[bool] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+        first: Optional[int] = 1000,
+        order_by: Optional[str] = "timestamp",
+        order_direction: Optional[str] = "desc",
+    ):  # -> List[LimitOrder]: # TODO: determine how we want to return this data
+        # handle the pair_name parameter
+        if pair_name:
+            base, quote = pair_name.split("/")
+            base_asset = ERC20.from_network(name=base, network=self.network)
+            quote_asset = ERC20.from_network(name=quote, network=self.network)
 
-            # handle the book_side parameter
-            if book_side and pair_name:
+        # handle the book_side parameter
+        if book_side and pair_name:
+            match book_side:
+                case OrderSide.BUY:
+                    buy_query = self.offer_query.offers_query(
+                        order_by,
+                        order_direction,
+                        first,
+                        maker,
+                        from_address,
+                        pay_gem=quote_asset.address,
+                        buy_gem=base_asset.address,
+                        open=open,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    buy_fields = self.offer_query.offers_fields(buy_query, False)
+                    buy_df = self.offer_query.query_offers(buy_fields, False)
+                    buy_df[
+                        "side"
+                    ] = "buy"  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
 
-                match book_side:
-                    case OrderSide.BUY:
-                        buy_query = self.offer_query.offers_query(order_by, order_direction, first, maker, from_address,
-                                                                pay_gem=quote_asset.address, buy_gem=base_asset.address,
-                                                                open=open, start_time=start_time, end_time=end_time)
-                        buy_fields = self.offer_query.offers_fields(buy_query, False)
-                        buy_df = self.offer_query.query_offers(buy_fields, False)
-                        buy_df['side'] = 'buy'  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
+                    bids = self.offer_query.dataframe_to_limit_orders(buy_df, pair_name)
 
-                        bids = self.offer_query.dataframe_to_limit_orders(buy_df, pair_name)
+                    return bids
 
-                        return bids
+                case OrderSide.SELL:
+                    sell_query = self.offer_query.offers_query(
+                        order_by,
+                        order_direction,
+                        first,
+                        maker,
+                        from_address,
+                        pay_gem=base_asset.address,
+                        buy_gem=quote_asset.address,
+                        open=open,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    sell_fields = self.offer_query.offers_fields(sell_query, False)
+                    sell_df = self.offer_query.query_offers(sell_fields, False)
+                    sell_df[
+                        "side"
+                    ] = "sell"  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
 
-                    case OrderSide.SELL:
-                        sell_query = self.offer_query.offers_query(order_by, order_direction, first, maker, from_address,
-                                                                pay_gem=base_asset.address, buy_gem=quote_asset.address,
-                                                                open=open, start_time=start_time, end_time=end_time)
-                        sell_fields = self.offer_query.offers_fields(sell_query, False)
-                        sell_df = self.offer_query.query_offers(sell_fields, False)
-                        sell_df['side'] = 'sell'  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
+                    asks = self.offer_query.dataframe_to_limit_orders(
+                        sell_df, pair_name
+                    )
 
-                        asks = self.offer_query.dataframe_to_limit_orders(sell_df, pair_name)
+                    return asks
 
-                        return asks
+                case OrderSide.NEUTRAL:
+                    buy_query = self.offer_query.offers_query(
+                        order_by,
+                        order_direction,
+                        first,
+                        maker,
+                        from_address,
+                        pay_gem=quote_asset.address,
+                        buy_gem=base_asset.address,
+                        open=open,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    buy_fields = self.offer_query.offers_fields(buy_query, False)
+                    buy_df = self.offer_query.query_offers(buy_fields, False)
+                    buy_df[
+                        "side"
+                    ] = "buy"  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
 
-                    case OrderSide.NEUTRAL:
-                        buy_query = self.offer_query.offers_query(order_by, order_direction, first, maker, from_address,
-                                                                pay_gem=quote_asset.address, buy_gem=base_asset.address,
-                                                                open=open, start_time=start_time, end_time=end_time)
-                        buy_fields = self.offer_query.offers_fields(buy_query, False)
-                        buy_df = self.offer_query.query_offers(buy_fields, False)
-                        buy_df['side'] = 'buy'  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
+                    sell_query = self.offer_query.offers_query(
+                        order_by,
+                        order_direction,
+                        first,
+                        maker,
+                        from_address,
+                        pay_gem=base_asset.address,
+                        buy_gem=quote_asset.address,
+                        open=open,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    sell_fields = self.offer_query.offers_fields(sell_query, False)
+                    sell_df = self.offer_query.query_offers(sell_fields, False)
+                    sell_df[
+                        "side"
+                    ] = "sell"  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
 
-                        sell_query = self.offer_query.offers_query(order_by, order_direction, first, maker, from_address,
-                                                                pay_gem=base_asset.address, buy_gem=quote_asset.address,
-                                                                open=open, start_time=start_time, end_time=end_time)
-                        sell_fields = self.offer_query.offers_fields(sell_query, False)
-                        sell_df = self.offer_query.query_offers(sell_fields, False)
-                        sell_df['side'] = 'sell'  # TODO: we could also pass this data to the offers_query method and handle it there, could help with price
+                    bids = self.offer_query.dataframe_to_limit_orders(buy_df, pair_name)
+                    asks = self.offer_query.dataframe_to_limit_orders(
+                        sell_df, pair_name
+                    )
 
-                        bids = self.offer_query.dataframe_to_limit_orders(buy_df, pair_name)
-                        asks = self.offer_query.dataframe_to_limit_orders(sell_df, pair_name)
-
-                        return [bids, asks]
-                    
-        
+                    return [bids, asks]

--- a/rubi/rubi/network/network.py
+++ b/rubi/rubi/network/network.py
@@ -12,6 +12,7 @@ from web3 import Web3
 class NetworkId(Enum):
     # MAINNET
     OPTIMISM = 10
+    ARBITRUM_ONE = 42161
 
     # TESTNET
     OPTIMISM_GOERLI = 420
@@ -36,6 +37,7 @@ class Network:
         rpc_url: str,
         explorer_url: str,
         market_data_url: str,
+        market_data_fallback_url: str,
         rubicon: dict,
         token_addresses: dict,
         # optional custom token config file from the user
@@ -78,6 +80,7 @@ class Network:
         # TODO: currently we are utilizing just a single url, we should switch to a dictionary as the number of
         #  subgraphs we support grows
         self.market_data_url = market_data_url
+        self.market_data_fallback_url = market_data_fallback_url
         self.rubicon = RubiconContracts(path=path, w3=self.w3, **rubicon)
 
         checksummed_token_addresses: dict[str, ChecksumAddress] = {}

--- a/rubi/rubi/rubicon_types/__init__.py
+++ b/rubi/rubi/rubicon_types/__init__.py
@@ -3,3 +3,4 @@ from .orderbook import *
 from .pair import *
 
 from .order_query import *
+from .trade_query import *

--- a/rubi/rubi/rubicon_types/order.py
+++ b/rubi/rubi/rubicon_types/order.py
@@ -38,6 +38,17 @@ class OrderSide(Enum):
             case OrderSide.SELL:
                 return -1
 
+    def opposite(self) -> "OrderSide":
+        match self:
+            case OrderSide.NEUTRAL:
+                return OrderSide.NEUTRAL
+
+            case OrderSide.BUY:
+                return OrderSide.SELL
+
+            case OrderSide.SELL:
+                return OrderSide.BUY
+
 
 class OrderType(Enum):
     """Enumeration representing the order type."""
@@ -137,6 +148,10 @@ class NewLimitOrder(BaseNewOrder):
 
         self.size = size
         self.price = price
+
+    def __repr__(self):
+        items = ("{}={!r}".format(k, self.__dict__[k]) for k in self.__dict__)
+        return "{}({})".format(type(self).__name__, ", ".join(items))
 
 
 class UpdateLimitOrder(BaseNewOrder):

--- a/rubi/rubi/rubicon_types/order.py
+++ b/rubi/rubi/rubicon_types/order.py
@@ -193,9 +193,10 @@ class NewCancelOrder(BaseNewOrder):
 
         self.order_id = order_id
 
+
 class LimitOrder(BaseNewOrder):
     """Class representing a detailed limit order.
-    
+
     :param pair_name: The name of the trading pair.
     :type pair_name: str
     :param order_type: The type of the order.
@@ -266,7 +267,6 @@ class LimitOrder(BaseNewOrder):
         removed_timestamp: Optional[int] = None,
         removed_block_number: Optional[int] = None,
     ):
-        
         # TODO: this is really an open discussion... we need an identifier for when the order was created that is inclusive of the: block, txn_index, and log_index
         # TODO: we will probably want to discuss the base_amt, base_amt_original, base_amt_filled, quote_amt, quote_amt_original, and quote_amt_filled. not sure if this is the best way to represent this data
 
@@ -298,7 +298,9 @@ class LimitOrder(BaseNewOrder):
         self.removed_block_number = removed_block_number
 
         if self.price is None:
-            self.price = quote_asset.to_decimal(quote_amt_original) / base_asset.to_decimal(base_amt_original)
+            self.price = quote_asset.to_decimal(
+                quote_amt_original
+            ) / base_asset.to_decimal(base_amt_original)
 
     def update_fill(
         self,
@@ -307,7 +309,7 @@ class LimitOrder(BaseNewOrder):
     ):
         # TODO: tracking the base asset and quote asset can be somewhat tricky, we will want to tie these into the events so that everything plays nicely together
         """A method to update the filled amounts of the order.
-        
+
         :param base_amt_filled: The updated filled base amount of the order.
         :type base_amt_filled: int
         :param quote_amt_filled: The updated filled quote amount of the order.
@@ -318,34 +320,35 @@ class LimitOrder(BaseNewOrder):
         self.quote_amt -= quote_amt_filled
         self.base_amt_filled += base_amt_filled
         self.quote_amt_filled += quote_amt_filled
-    
+
     def update_cancel(
         self,
         removed_timestamp: Optional[int] = None,
         removed_block_number: Optional[int] = None,
     ):
         """A method to update the order when it is cancelled."""
-        
+
         self.open = False
         self.base_amt = 0
         self.quote_amt = 0
         self.removed_timestamp = removed_timestamp
         self.removed_block_number = removed_block_number
-        
+
     # TODO: do we want a function to return the asset amounts as decimals? or should we just use the ERC20.to_decimal() function?
     def get_size(self) -> Decimal:
         """Returns the size of the order.
-        
+
         :return: The size of the order.
         :rtype: Decimal
         """
-        
+
         return self.base_asset.to_decimal(self.base_amt)
-    
+
     # repr
     def __repr__(self):
         items = ("{}={!r}".format(k, self.__dict__[k]) for k in self.__dict__)
         return "{}({})".format(type(self).__name__, ", ".join(items))
+
 
 class Transaction:
     """

--- a/rubi/rubi/rubicon_types/order.py
+++ b/rubi/rubi/rubicon_types/order.py
@@ -13,6 +13,7 @@ from rubi.contracts.contract_types.events import (
     EmitFeeEvent,
 )
 from rubi.rubicon_types.pair import Pair
+from rubi.contracts import ERC20
 
 
 class OrderSide(Enum):
@@ -192,9 +193,159 @@ class NewCancelOrder(BaseNewOrder):
 
         self.order_id = order_id
 
+class LimitOrder(BaseNewOrder):
+    """Class representing a detailed limit order.
+    
+    :param pair_name: The name of the trading pair.
+    :type pair_name: str
+    :param order_type: The type of the order.
+    :type order_type: OrderType
+    :param order_side: The side of the order (buy or sell).
+    :type order_side: OrderSide
+    :param id: The ID of the order.
+    :type id: int
+    :param timestamp: The timestamp of when the order was created.
+    :type timestamp: int
+    :param block_number: The block number of when the order was created.
+    :type block_number: int
+    :param block_index: The index of the transaction in the block of when the order was created.
+    :type block_index: int
+    :param log_index: The index of the log in the transaction of when the order was created.
+    :type log_index: int
+    :param txn_hash: The hash of the transaction of when the order was created.
+    :type txn_hash: str # TODO: this probably has a type that we can import from web3
+    :param maker: The address of the maker of the order.
+    :type maker: ChecksumAddress
+    :param base_asset: The asset being traded.
+    :type base_asset: ERC20
+    :param quote_asset: The quote asset.
+    :type quote_asset: ERC20
+    :param base_amt: The base amount of the order.
+    :type base_amt: int
+    :param quote_amt: The quote amount of the order.
+    :type quote_amt: int
+    :param base_amt_original: The original base amount of the order.
+    :type base_amt_original: int
+    :param quote_amt_original: The original quote amount of the order.
+    :type quote_amt_original: int
+    :param base_amt_filled: The filled base amount of the order.
+    :type base_amt_filled: int
+    :param quote_amt_filled: The filled quote amount of the order.
+    :type quote_amt_filled: int
+    :param price: The price of the order.
+    :type price: Decimal # TODO: worth discussing if this should be the ratio of the raw amounts or the ratio of the decimal amounts - for now im opting for decimals for readability but that may limit precision
+    :param open: Whether or not the order is open.
+    :type open: bool
+    :param removed_timestamp: The timestamp of when the order was removed (optional).
+    :type removed_timestamp: Optional[int]
+    :param removed_block_number: The block number of when the order was removed (optional).
+    :type removed_block_number: Optional[int]
+    """
 
-# TODO: add a new class for a limit order object that is returned from the subgraph
+    def __init__(
+        self,
+        pair_name: str,
+        order_side: OrderSide,
+        id: int,
+        timestamp: int,
+        block_number: int,
+        block_index: int,
+        log_index: int,
+        txn_hash: str,
+        maker: ChecksumAddress,
+        base_asset: ERC20,
+        quote_asset: ERC20,
+        base_amt: int,
+        quote_amt: int,
+        base_amt_original: int,
+        quote_amt_original: int,
+        base_amt_filled: int,
+        quote_amt_filled: int,
+        open: bool,
+        price: Optional[Decimal] = None,
+        removed_timestamp: Optional[int] = None,
+        removed_block_number: Optional[int] = None,
+    ):
+        
+        # TODO: this is really an open discussion... we need an identifier for when the order was created that is inclusive of the: block, txn_index, and log_index
+        # TODO: we will probably want to discuss the base_amt, base_amt_original, base_amt_filled, quote_amt, quote_amt_original, and quote_amt_filled. not sure if this is the best way to represent this data
 
+        """constructor method."""
+        super().__init__(
+            pair_name=pair_name,
+            order_type=OrderType.LIMIT,
+            order_side=order_side,
+        )
+
+        self.id = id
+        self.timestamp = timestamp
+        self.block_number = block_number
+        self.block_index = block_index
+        self.log_index = log_index
+        self.txn_hash = txn_hash
+        self.maker = maker
+        self.base_asset = base_asset
+        self.quote_asset = quote_asset
+        self.base_amt = base_amt
+        self.quote_amt = quote_amt
+        self.base_amt_original = base_amt_original
+        self.quote_amt_original = quote_amt_original
+        self.base_amt_filled = base_amt_filled
+        self.quote_amt_filled = quote_amt_filled
+        self.open = open
+        self.price = price
+        self.removed_timestamp = removed_timestamp
+        self.removed_block_number = removed_block_number
+
+        if self.price is None:
+            self.price = quote_asset.to_decimal(quote_amt_original) / base_asset.to_decimal(base_amt_original)
+
+    def update_fill(
+        self,
+        base_amt_filled: int,
+        quote_amt_filled: int,
+    ):
+        # TODO: tracking the base asset and quote asset can be somewhat tricky, we will want to tie these into the events so that everything plays nicely together
+        """A method to update the filled amounts of the order.
+        
+        :param base_amt_filled: The updated filled base amount of the order.
+        :type base_amt_filled: int
+        :param quote_amt_filled: The updated filled quote amount of the order.
+        :type quote_amt_filled: int
+        """
+
+        self.base_amt -= base_amt_filled
+        self.quote_amt -= quote_amt_filled
+        self.base_amt_filled += base_amt_filled
+        self.quote_amt_filled += quote_amt_filled
+    
+    def update_cancel(
+        self,
+        removed_timestamp: Optional[int] = None,
+        removed_block_number: Optional[int] = None,
+    ):
+        """A method to update the order when it is cancelled."""
+        
+        self.open = False
+        self.base_amt = 0
+        self.quote_amt = 0
+        self.removed_timestamp = removed_timestamp
+        self.removed_block_number = removed_block_number
+        
+    # TODO: do we want a function to return the asset amounts as decimals? or should we just use the ERC20.to_decimal() function?
+    def get_size(self) -> Decimal:
+        """Returns the size of the order.
+        
+        :return: The size of the order.
+        :rtype: Decimal
+        """
+        
+        return self.base_asset.to_decimal(self.base_amt)
+    
+    # repr
+    def __repr__(self):
+        items = ("{}={!r}".format(k, self.__dict__[k]) for k in self.__dict__)
+        return "{}({})".format(type(self).__name__, ", ".join(items))
 
 class Transaction:
     """

--- a/rubi/rubi/rubicon_types/order_query.py
+++ b/rubi/rubi/rubicon_types/order_query.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Union
 
 import pandas as pd
 from eth_typing import ChecksumAddress
@@ -125,10 +125,10 @@ class OrderQuery:
         order_by: str,
         order_direction: str,
         first: int,
-        maker: Optional[str] = None,
-        from_address: Optional[str] = None,
-        pay_gem: Optional[str] = None,
-        buy_gem: Optional[str] = None,
+        maker: Optional[Union[ChecksumAddress, str]] = None,
+        from_address: Optional[Union[ChecksumAddress, str]] = None,
+        pay_gem: Optional[Union[ChecksumAddress, str]] = None,
+        buy_gem: Optional[Union[ChecksumAddress, str]] = None,
         open: Optional[bool] = None,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
@@ -169,10 +169,12 @@ class OrderQuery:
 
         # build the list of where conditions
         where = [
-            self.offer.maker == maker.lower() if maker else None,
-            self.offer.from_address == from_address.lower() if from_address else None,
-            self.offer.pay_gem == pay_gem.lower() if pay_gem else None,
-            self.offer.buy_gem == buy_gem.lower() if buy_gem else None,
+            self.offer.maker == str(maker).lower() if maker else None,
+            self.offer.from_address == str(from_address).lower()
+            if from_address
+            else None,
+            self.offer.pay_gem == str(pay_gem).lower() if pay_gem else None,
+            self.offer.buy_gem == str(buy_gem).lower() if buy_gem else None,
             self.offer.open == open if open is not None else None,
             self.offer.timestamp >= start_time if start_time else None,
             self.offer.timestamp <= end_time if end_time else None,

--- a/rubi/rubi/rubicon_types/order_query.py
+++ b/rubi/rubi/rubicon_types/order_query.py
@@ -14,6 +14,10 @@ from rubi.network import (
     Network,
 )
 
+from rubi.rubicon_types import (
+    LimitOrder,
+    OrderSide,
+)
 
 class OrderQuery:
     def __init__(
@@ -313,3 +317,59 @@ class OrderQuery:
 
         # TODO: apply any data type conversions to the dataframe - possibly converting unformatted values to integers
         return df
+
+    def dataframe_to_limit_orders(
+                self,
+                df: pd.DataFrame, 
+                pair_name: str
+            ) -> List[LimitOrder]:
+            """Converts a DataFrame of order data into a list of LimitOrder objects."""
+                    
+            def row_to_limitorder(row: pd.Series) -> LimitOrder:
+
+                if row['side'] == 'buy': # TODO: there is probably a better way to do this
+                    base_asset = self.get_token(row['buy_gem'])
+                    quote_asset = self.get_token(row['pay_gem'])
+
+                    base_asset_amt = row['buy_amt']
+                    quote_asset_amt = row['pay_amt']
+                    base_asset_amt_filled = row['bought_amt']
+                    quote_asset_amt_filled = row['paid_amt']
+
+                    order_side = OrderSide.BUY
+                else:
+                    base_asset = self.get_token(row['pay_gem'])
+                    quote_asset = self.get_token(row['buy_gem'])
+
+                    base_asset_amt = row['pay_amt']
+                    quote_asset_amt = row['buy_amt']
+                    base_asset_amt_filled = row['paid_amt'] 
+                    quote_asset_amt_filled = row['bought_amt']
+
+                    order_side = OrderSide.SELL
+                
+                return LimitOrder(
+                    pair_name=pair_name,
+                    order_side=order_side,
+                    id=row['id'],
+                    timestamp=row['timestamp'],
+                    block_number=row['transaction_block_number'],
+                    block_index=row['transaction_block_index'],
+                    log_index=row['index'],  # Assume 0 if 'log_index' column doesn't exist
+                    txn_hash=row['transaction'],
+                    maker=self.network.w3.to_checksum_address(row['maker']),
+                    base_asset=base_asset,
+                    quote_asset=quote_asset,
+                    base_amt=base_asset_amt - base_asset_amt_filled,
+                    quote_amt=quote_asset_amt - quote_asset_amt_filled,
+                    base_amt_original=base_asset_amt,
+                    quote_amt_original=quote_asset_amt,
+                    base_amt_filled=base_asset_amt_filled,
+                    quote_amt_filled=quote_asset_amt_filled,
+                    open=row['open'],
+                    price=None, # we want to calculate this on the fly based on direction
+                    removed_timestamp=row.get('removed_timestamp', None),  # Use None if 'removed_timestamp' doesn't exist
+                    removed_block_number=row.get('removed_block', None)  # Use None if 'removed_block' doesn't exist
+                )
+            
+            return df.apply(row_to_limitorder, axis=1).tolist()

--- a/rubi/rubi/rubicon_types/order_query.py
+++ b/rubi/rubi/rubicon_types/order_query.py
@@ -19,6 +19,7 @@ from rubi.rubicon_types import (
     OrderSide,
 )
 
+
 class OrderQuery:
     def __init__(
         self,
@@ -319,57 +320,58 @@ class OrderQuery:
         return df
 
     def dataframe_to_limit_orders(
-                self,
-                df: pd.DataFrame, 
-                pair_name: str
-            ) -> List[LimitOrder]:
-            """Converts a DataFrame of order data into a list of LimitOrder objects."""
-                    
-            def row_to_limitorder(row: pd.Series) -> LimitOrder:
+        self, df: pd.DataFrame, pair_name: str
+    ) -> List[LimitOrder]:
+        """Converts a DataFrame of order data into a list of LimitOrder objects."""
 
-                if row['side'] == 'buy': # TODO: there is probably a better way to do this
-                    base_asset = self.get_token(row['buy_gem'])
-                    quote_asset = self.get_token(row['pay_gem'])
+        def row_to_limitorder(row: pd.Series) -> LimitOrder:
+            if row["side"] == "buy":  # TODO: there is probably a better way to do this
+                base_asset = self.get_token(row["buy_gem"])
+                quote_asset = self.get_token(row["pay_gem"])
 
-                    base_asset_amt = row['buy_amt']
-                    quote_asset_amt = row['pay_amt']
-                    base_asset_amt_filled = row['bought_amt']
-                    quote_asset_amt_filled = row['paid_amt']
+                base_asset_amt = row["buy_amt"]
+                quote_asset_amt = row["pay_amt"]
+                base_asset_amt_filled = row["bought_amt"]
+                quote_asset_amt_filled = row["paid_amt"]
 
-                    order_side = OrderSide.BUY
-                else:
-                    base_asset = self.get_token(row['pay_gem'])
-                    quote_asset = self.get_token(row['buy_gem'])
+                order_side = OrderSide.BUY
+            else:
+                base_asset = self.get_token(row["pay_gem"])
+                quote_asset = self.get_token(row["buy_gem"])
 
-                    base_asset_amt = row['pay_amt']
-                    quote_asset_amt = row['buy_amt']
-                    base_asset_amt_filled = row['paid_amt'] 
-                    quote_asset_amt_filled = row['bought_amt']
+                base_asset_amt = row["pay_amt"]
+                quote_asset_amt = row["buy_amt"]
+                base_asset_amt_filled = row["paid_amt"]
+                quote_asset_amt_filled = row["bought_amt"]
 
-                    order_side = OrderSide.SELL
-                
-                return LimitOrder(
-                    pair_name=pair_name,
-                    order_side=order_side,
-                    id=row['id'],
-                    timestamp=row['timestamp'],
-                    block_number=row['transaction_block_number'],
-                    block_index=row['transaction_block_index'],
-                    log_index=row['index'],  # Assume 0 if 'log_index' column doesn't exist
-                    txn_hash=row['transaction'],
-                    maker=self.network.w3.to_checksum_address(row['maker']),
-                    base_asset=base_asset,
-                    quote_asset=quote_asset,
-                    base_amt=base_asset_amt - base_asset_amt_filled,
-                    quote_amt=quote_asset_amt - quote_asset_amt_filled,
-                    base_amt_original=base_asset_amt,
-                    quote_amt_original=quote_asset_amt,
-                    base_amt_filled=base_asset_amt_filled,
-                    quote_amt_filled=quote_asset_amt_filled,
-                    open=row['open'],
-                    price=None, # we want to calculate this on the fly based on direction
-                    removed_timestamp=row.get('removed_timestamp', None),  # Use None if 'removed_timestamp' doesn't exist
-                    removed_block_number=row.get('removed_block', None)  # Use None if 'removed_block' doesn't exist
-                )
-            
-            return df.apply(row_to_limitorder, axis=1).tolist()
+                order_side = OrderSide.SELL
+
+            return LimitOrder(
+                pair_name=pair_name,
+                order_side=order_side,
+                id=row["id"],
+                timestamp=row["timestamp"],
+                block_number=row["transaction_block_number"],
+                block_index=row["transaction_block_index"],
+                log_index=row["index"],  # Assume 0 if 'log_index' column doesn't exist
+                txn_hash=row["transaction"],
+                maker=self.network.w3.to_checksum_address(row["maker"]),
+                base_asset=base_asset,
+                quote_asset=quote_asset,
+                base_amt=base_asset_amt - base_asset_amt_filled,
+                quote_amt=quote_asset_amt - quote_asset_amt_filled,
+                base_amt_original=base_asset_amt,
+                quote_amt_original=quote_asset_amt,
+                base_amt_filled=base_asset_amt_filled,
+                quote_amt_filled=quote_asset_amt_filled,
+                open=row["open"],
+                price=None,  # we want to calculate this on the fly based on direction
+                removed_timestamp=row.get(
+                    "removed_timestamp", None
+                ),  # Use None if 'removed_timestamp' doesn't exist
+                removed_block_number=row.get(
+                    "removed_block", None
+                ),  # Use None if 'removed_block' doesn't exist
+            )
+
+        return df.apply(row_to_limitorder, axis=1).tolist()

--- a/rubi/rubi/rubicon_types/orderbook.py
+++ b/rubi/rubi/rubicon_types/orderbook.py
@@ -2,7 +2,7 @@ from _decimal import Decimal
 from typing import List, Tuple
 
 from rubi import ERC20
-from rubi.rubicon_types.order import OrderSide
+from rubi.rubicon_types.order import OrderSide, LimitOrder
 
 
 class BookLevel:
@@ -190,4 +190,382 @@ class OrderBook:
         return "{}({})".format(type(self).__name__, ", ".join(items))
 
 
-# TODO: add a DetailedOrderBook class that contains the full order book composed of LimitOrder instances
+class DetailedBookLevel(BookLevel):
+    """Class representing a level in the detailed order book.
+    
+    :param price: The price of the level.
+    :type price: Decimal
+    :param size: The size of the level.
+    :type size: Decimal # TODO: determine if we really want to use a decimal here, or if we want to just make a new type that doesn't extend BookLevel
+    :param orders: The list of orders at the level.
+    :type orders: List[LimitOrder] # TODO: determine if we really need to order these, i believe the order book follows a FIFO model
+    """
+
+    # TODO: may be worth checking out something like sortedcontainers to make this more efficient
+    
+    def __init__(
+        self, 
+        price: Decimal,
+        size: Decimal,
+        orders: List[LimitOrder]
+    ): 
+        """constructor method."""
+        super().__init__(price, size)
+        
+        if not all(order.price == price for order in orders):
+            raise ValueError("Order price does not match level price.") # TODO: maybe an unecessary check, but it's good to be safe
+        
+        # Sort orders by block number, block index, and transaction index
+        self.orders = sorted(
+            orders, 
+            key=lambda order: (order.block_number, order.block_index, order.log_index)
+        )
+
+    @classmethod
+    def from_rubicon_offers(
+        cls,
+        orders: List[LimitOrder]
+    ):
+
+        price = orders[0].price
+        size = sum(order.get_size() for order in orders)
+        
+        return cls(price, size, orders)
+    
+    def add_order(
+        self, 
+        order: LimitOrder,
+        sort: bool = False
+    ): 
+        """Add an order to the level.
+        
+        :param order: The order to add to the level.
+        :type order: LimitOrder
+        :param sort: Whether or not to sort the orders after adding the new order.
+        :type sort: bool
+        """
+        if order.price != self.price:
+            raise ValueError("Order price does not match level price.")
+        
+        self.orders.append(order)
+        self.size += order.get_size()
+        
+        if sort:
+            self.orders = sorted(
+                self.orders, 
+                key=lambda order: (order.block_number, order.block_index, order.log_index)
+            )
+
+    def remove_order(
+            self, 
+            id: int
+        ):
+        """Remove an order from the level.
+
+        :param id: The id of the order to remove.
+        :type id: int
+        """
+        
+        for i, order in enumerate(self.orders):
+            if order.id == id:
+                
+                self.size -= self.orders[i].get_size()
+
+                del self.orders[i]
+                return
+        
+        # If we didn't find the order, raise an error
+        raise ValueError(f"Order with id {id} not found.") # TODO: maybe we should just log an error here instead of raising an exception
+    
+    def update_order(
+        self, 
+        id: int,
+        base_amt_filled: int, 
+        quote_amt_filled: int
+    ): 
+        """Update an order in the level.
+        
+        :param id: The id of the order to update.
+        :type id: int
+        :param base_amt_filled: The amount of the base asset that has been filled.
+        :type base_amt_filled: int
+        :param quote_amt_filled: The amount of the quote asset that has been filled.
+        :type quote_amt_filled: int
+        """
+
+        for i, order in enumerate(self.orders):
+            if order.id == id: 
+                self.orders[i].update_fill(base_amt_filled, quote_amt_filled)
+                self.size -= self.orders[i].get_size()
+                return
+        
+        # If we didn't find the order, raise an error
+        raise ValueError(f"Order with id {id} not found.") # TODO: maybe we should just log an error here instead of raising an exception
+
+class DetailedBookSide(BookSide): 
+    """Class representing a side of the detailed order book. Either bids or asks.
+    
+    :param book_side: The side of the order book (BUY or SELL).
+    :type book_side: OrderSide
+    :param levels: The list of levels on the side.
+    :type levels: List[DetailedBookLevel]
+    """
+
+    def __init__(
+        self, 
+        book_side: OrderSide, 
+        levels: List[DetailedBookLevel]
+    ):
+        """constructor method."""
+        super().__init__(book_side, levels)
+
+        # TODO: decide if this is the best path forward
+        # for ease of use, we will store a dictionary that maps the id of the offer to the level it is in
+        self.offer_to_level = {}
+        for level in self.levels:
+            for order in level.orders:
+                self.offer_to_level[order.id] = level
+
+        # TODO: decide if this is the best path forward
+        # for ease of use, we will store a dictionary that maps every price to the level it is in
+        self.price_to_level = {}
+        for level in self.levels:
+            self.price_to_level[level.price] = level
+
+    @classmethod
+    def from_rubicon_offers(
+        cls,
+        book_side: OrderSide,
+        offers: List[LimitOrder]
+    ):
+        """Creates a DetailedBookSide instance from a list of LimitOrders.
+        
+        :param book_side: The side of the order book (BUY or SELL).
+        :type book_side: OrderSide
+        :param offers: The list of offers retrieved from the Rubicon for an asset pair pay_gem/buy_gem.
+        """
+
+        # go through and get every price level that we will need
+        levels = {}
+
+        for order in offers:
+            if order.price in levels:
+                levels[order.price].append(order)
+            else:
+                levels[order.price] = [order]
+
+        # construct the levels list
+        levels_list = []
+        for price, orders in levels.items():
+            levels_list.append(DetailedBookLevel.from_rubicon_offers(orders))
+
+        # sort the levels list 
+        match book_side:
+            case OrderSide.BUY:
+                levels_list = sorted(
+                    levels_list, 
+                    key=lambda level: level.price, 
+                    reverse=True
+                )
+            case OrderSide.SELL:
+                levels_list = sorted(
+                    levels_list, 
+                    key=lambda level: level.price
+                )
+
+        return cls(
+            book_side=book_side,
+            levels=levels_list
+        )
+    
+    def add_order(
+        self, 
+        order: LimitOrder
+    ):
+        """Add an order to the detailed book side.
+        
+        :param order: The order to add to the detailed book side.
+        :type order: LimitOrder
+        """
+
+        if order.price in self.price_to_level:
+            self.price_to_level[order.price].add_order(order)
+            self.offer_to_level[order.id] = self.price_to_level[order.price]
+        else:
+            self.price_to_level[order.price] = DetailedBookLevel.from_rubicon_offers([order])
+            self.offer_to_level[order.id] = self.price_to_level[order.price]
+
+    def remove_order(
+        self, 
+        id: int
+    ):
+        """Remove an order from the detailed book side.
+        
+        :param id: The id of the order to remove.
+        :type id: int
+        """
+
+        if id in self.offer_to_level:
+            self.offer_to_level[id].remove_order(id)
+            del self.offer_to_level[id]
+
+            if self.offer_to_level[id].size == 0:    
+                del self.price_to_level[self.offer_to_level[id].price]
+            
+        else:
+            raise ValueError(f"Order with id {id} not found.") # TODO: maybe we should just log an error here instead of raising an exception
+        
+    def update_order(
+        self, 
+        id: int,
+        base_amt_filled: int,
+        quote_amt_filled: int
+    ):
+        
+        if id in self.offer_to_level:
+            self.offer_to_level[id].update_order(id, base_amt_filled, quote_amt_filled)
+        else:
+            raise ValueError(f"Order with id {id} not found.") # TODO: maybe we should just log an error here instead of raising an exception
+
+    def best_price(self) -> Decimal:
+        """Returns the price of the best level on the book side.
+
+        :return: The price of the best level.
+        :rtype: Decimal
+        """
+        return self.levels[0].price
+    
+    def best_offer(self) -> LimitOrder:
+        """Returns the best offer on the book side.
+
+        :return: The best offer.
+        :rtype: LimitOrder
+        """
+        return self.levels[0].orders[0]
+
+    # remove_liquidity_from_book is inherited from BookSide
+    # def remove_liquidity_from_book(self, price: Decimal, size: Decimal):
+    # TODO: decide if we want to keep this method or simply over write it with an error message
+    def remove_liquidity_from_book(self, price: Decimal, size: Decimal):
+        raise Exception("this method should not be called on a DetailedBookSide instance")
+    
+class DetailedOrderBook(OrderBook):
+    """Class represents a DetailedOrderBook.
+    
+    :param bids: BookSide representing the bid orders.
+    :type bids: DetailedBookSide
+    :param asks: BookSide representing the ask orders.
+    :type asks: DetailedBookSide
+    """
+
+    def __init__(self, bids: DetailedBookSide, asks: DetailedBookSide):
+        """constructor method."""
+        super().__init__(bids, asks)
+
+        self.bid_ids = {bid_id for bid_id in self.bids.offer_to_level.keys()}
+        self.ask_ids = {ask_id for ask_id in self.asks.offer_to_level.keys()}
+
+    @classmethod
+    def from_rubicon_offer_book(
+        cls, 
+        offer_book: Tuple[List[LimitOrder], List[LimitOrder]]
+    ):
+
+        bids=DetailedBookSide.from_rubicon_offers(
+            book_side=OrderSide.BUY, 
+            offers=offer_book[0]
+        )
+        asks=DetailedBookSide.from_rubicon_offers(
+            book_side=OrderSide.SELL, 
+            offers=offer_book[1]
+        )
+        return cls(
+            bids, 
+            asks
+        )
+    
+    def add_order(
+        self,
+        order: LimitOrder
+    ):
+        """Add an order to the detailed order book.
+        
+        :param order: The order to add to the detailed order book.
+        :type order: LimitOrder
+        """
+
+        match order.side:
+            case OrderSide.BUY:
+                self.bid_ids.add(order.id)
+                self.bids.add_order(order)
+            case OrderSide.SELL:
+                self.ask_ids.add(order.id)
+                self.asks.add_order(order)
+    
+    def remove_order(
+        self,
+        id: int
+    ):
+        """Remove an order from the detailed order book.
+        
+        :param id: The id of the order to remove.
+        :type id: int
+        """
+
+        if id in self.bid_ids:
+            self.bids.remove_order(id)
+            self.bid_ids.remove(id)
+        elif id in self.ask_ids:
+            self.asks.remove_order(id)
+            self.ask_ids.remove(id)
+        else:
+            raise ValueError(f"Order with id {id} not found.")
+
+    def update_order(
+        self,
+        id: int,
+        base_amt_filled: int,
+        quote_amt_filled: int
+    ):
+        """Update an order in the detailed order book.
+        
+        :param id: The id of the order to update.
+        :type id: int
+        :param base_amt_filled: The amount of the base asset that has been filled.
+        :type base_amt_filled: int
+        :param quote_amt_filled: The amount of the quote asset that has been filled.
+        :type quote_amt_filled: int
+        """
+
+        if id in self.bid_ids:
+            self.bids.update_order(id, base_amt_filled, quote_amt_filled)
+        elif id in self.ask_ids:
+            self.asks.update_order(id, base_amt_filled, quote_amt_filled)
+        else:
+            raise ValueError(f"Order with id {id} not found.")
+    
+    # TODO: determine if there is any need to modify the best_bid, best_ask, mid_price, and spread methods
+    # def best_bid(self) -> Decimal:
+    # def best_ask(self) -> Decimal:
+    # def mid_price(self) -> Decimal:
+    # def spread(self) -> Decimal:
+
+    def best_bid_offer(self) -> LimitOrder:
+        """Returns the best bid offer on the book.
+
+        :return: The best bid offer.
+        :rtype: LimitOrder
+        """
+        
+        return self.bids.best_offer()
+    
+    def best_ask_offer(self) -> LimitOrder:
+        """Returns the best ask offer on the book.
+
+        :return: The best ask offer.
+        :rtype: LimitOrder
+        """
+        return self.asks.best_offer()
+
+    # TODO: 
+    # def get_order(self, id: int) -> LimitOrder:

--- a/rubi/rubi/rubicon_types/trade_query.py
+++ b/rubi/rubi/rubicon_types/trade_query.py
@@ -1,0 +1,329 @@
+from datetime import datetime
+from typing import List, Optional, Dict, Any, Union
+
+import pandas as pd
+from eth_typing import ChecksumAddress
+from subgrounds import Subgrounds
+from subgrounds.pagination import ShallowStrategy
+from subgrounds.subgraph import SyntheticField
+
+from rubi.contracts import (
+    ERC20,
+)
+from rubi.network import (
+    Network,
+)
+
+
+class TradeQuery:
+    def __init__(
+        self,
+        subgrounds: Subgrounds,
+        subgraph,  # TODO: determine the type that should be used here
+        network: Optional[Network] = None,
+        network_tokens: Optional[Dict[ChecksumAddress, ERC20]] = None,
+    ):
+        self.sg = subgrounds
+        self.data = subgraph
+        self.network = network
+        self.tokens = network_tokens
+        self.trade = self.trade_entity()
+
+    # TODO: we will want to move this somewhere else most likely - we can't access the client from here though so we
+    #  will need to figure out how to do that
+    #####################################
+    # General Helper Methods
+    #####################################
+
+    def get_token(self, token_address: str) -> ERC20:
+        """Returns an ERC20 object for the token address passed from the token_map if it exists or add it to the
+        self.tokens if it does not exist.
+        """
+
+        if not self.tokens:
+            raise ValueError("No network object initialized on the class.")
+        else:
+            try:
+                token_address = self.network.w3.to_checksum_address(token_address)
+
+                if token_address not in self.tokens:
+                    self.tokens[token_address] = ERC20.from_address(
+                        w3=self.network.w3, address=token_address
+                    )
+
+                return self.tokens[token_address]
+
+            except:
+                raise ValueError(f"Token address: {token_address} is invalid.")
+
+    #####################################
+    # Query Methods                     #
+    #####################################
+
+    """
+    {
+    takes {
+        id
+        index
+        timestamp
+        transaction {
+            id
+            timestamp
+            block_number
+            block_index
+        }
+        taker {
+            id
+        }
+        from_address {
+            id
+        }
+        take_gem
+        give_gem
+        take_amt
+        give_amt
+        offer {
+            maker {
+                id
+            }
+            from_address {
+                id
+            }
+            index
+            transaction {
+                id
+                block_number
+                block_index
+            }
+        }
+    }
+    }   
+    """
+
+    def trade_entity(
+        self,
+    ):  # TODO: return a typed object (see subgrounds documentation for more info)
+        Take = self.data.Take
+
+        # if we have a network object we can get all the token information we need
+        if self.network:
+            Take.take_amt_formatted = SyntheticField(
+                f=lambda take_amt, take_gem: self.get_token(take_gem).to_decimal(
+                    take_amt
+                ),
+                type_=SyntheticField.FLOAT,
+                deps=[Take.take_amt, Take.take_gem],
+            )
+
+            Take.give_amt_formatted = SyntheticField(
+                f=lambda give_amt, give_gem: self.get_token(give_gem).to_decimal(
+                    give_amt
+                ),
+                type_=SyntheticField.FLOAT,
+                deps=[Take.give_amt, Take.give_gem],
+            )
+
+            Take.take_gem_symbol = SyntheticField(
+                f=lambda take_gem: self.get_token(take_gem).symbol,
+                type_=SyntheticField.STRING,
+                deps=[Take.take_gem],
+            )
+
+            Take.give_gem_symbol = SyntheticField(
+                f=lambda give_gem: self.get_token(give_gem).symbol,
+                type_=SyntheticField.STRING,
+                deps=[Take.give_gem],
+            )
+
+            Take.datetime = SyntheticField(
+                f=lambda timestamp: str(datetime.fromtimestamp(timestamp)),
+                type_=SyntheticField.STRING,
+                deps=[Take.timestamp],
+            )
+
+        return Take
+
+    def trades_query(
+        self,
+        order_by: str,
+        order_direction: str,
+        first: int,
+        # maker: Optional[str] = None, TODO: resolve #63 and add in conditional filter for offer maker/from_address
+        taker: Optional[Union[str, ChecksumAddress]] = None,
+        from_address: Optional[Union[ChecksumAddress, str]] = None,
+        take_gem: Optional[Union[ChecksumAddress, str]] = None,
+        give_gem: Optional[Union[ChecksumAddress, str]] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+        # TODO: there is definitely a clear way to pass these parameters in a more concise way, prolly **kargs
+    ):  # TODO: return a typed object (see subgrounds documentation for more info)
+        # determine that the parameters are valid
+        error_messages = []
+
+        # check the order_by parameter
+        if order_by.lower() not in ("timestamp"):
+            error_messages.append(
+                "Invalid order_by, must be 'timestamp' (default: timestamp)"
+            )
+        elif order_by.lower() == "timestamp":
+            order_by = self.trade.timestamp
+
+        # check the order_direction parameter
+        if order_direction.lower() not in ("asc", "desc"):
+            error_messages.append(
+                "Invalid order_direction, must be 'asc' or 'desc' (default: desc)"
+            )
+        else:
+            order_direction = order_direction.lower()
+
+        # check the first parameter
+        if first < 1:
+            error_messages.append(
+                "Invalid first, must be greater than 0 (default: 1000)"
+            )
+        if not isinstance(first, int):
+            error_messages.append("Invalid first, must be an integer (default: 1000)")
+
+        # raise an error if there are any
+        if error_messages:
+            raise ValueError("\n".join(error_messages))
+
+        # build the list of where conditions
+        where = [
+            self.trade.taker == str(taker).lower() if taker else None,
+            self.trade.from_address == str(from_address).lower()
+            if from_address
+            else None,
+            self.trade.take_gem == str(take_gem).lower() if take_gem else None,
+            self.trade.give_gem == str(give_gem).lower() if give_gem else None,
+            self.trade.timestamp >= start_time if start_time else None,
+            self.trade.timestamp <= end_time if end_time else None,
+        ]
+        where = [condition for condition in where if condition is not None]
+
+        """Helper method to build a query for the take subgraph entity."""
+        trades = self.data.Query.takes(
+            orderBy=order_by,
+            orderDirection=order_direction,
+            first=first,
+            where=where if where else {},
+        )
+
+        return trades
+
+    def trades_fields(
+        self,
+        trades: Any,  # TODO: check that this is the correct type (subgrounds may have types that we can utilize here)
+        formatted: bool = False,
+    ):  # TODO: return a typed object (see subgrounds documentation for more info)
+        """Helper method to build a list of fields for the offers subgraph entity."""
+        fields = [
+            trades.id,
+            trades.timestamp,
+            trades.take_gem,
+            trades.give_gem,
+            trades.take_amt,
+            trades.give_amt,
+            trades.taker.id,
+            trades.from_address.id,
+            trades.transaction.block_number,
+            trades.transaction.block_index,
+            trades.index,
+            trades.offer.maker.id,
+            trades.offer.from_address.id,
+            trades.offer.transaction.block_number,
+            trades.offer.transaction.block_index,
+            trades.offer.index,
+        ]
+
+        if formatted:
+            fields.append(trades.take_amt_formatted)
+            fields.append(trades.give_amt_formatted)
+            fields.append(trades.take_gem_symbol)
+            fields.append(trades.give_gem_symbol)
+            fields.append(trades.datetime)
+
+        return fields
+
+    def query_trades(
+        self,
+        fields: List,
+        formatted: bool = False,
+        # TOOD: maybe we give the user the option to define a custom pagination strategy?
+    ):  # TODO: return a typed object (see subgrounds documentation for more info)
+        """Helper method to query the offers subgraph entity."""
+        df = self.sg.query_df(fields, pagination_strategy=ShallowStrategy)
+
+        # if the dataframe is empty, return an empty dataframe with the correct columns
+        if df.empty and not formatted:
+            cols = [
+                "id",
+                "timestamp",
+                "take_gem",
+                "give_gem",
+                "take_amt",
+                "give_amt",
+                "taker",
+                "from_address",
+                "block_number",
+                "block_index",
+                "log_index",
+                "maker",
+                "maker_from_address",
+                "offer_block_number",
+                "offer_block_index",
+                "offer_log_index",
+            ]
+            df = pd.DataFrame(columns=cols)
+
+        elif df.empty and formatted:
+            cols = [
+                "taker",
+                "from_address",
+                "take_gem",
+                "give_gem",
+                "take_amt",
+                "give_amt",
+                "timestamp",
+                "maker",
+                "maker_from_address",
+                "block_number",
+                "block_index",
+                "log_index",
+            ]
+            df = pd.DataFrame(columns=cols)
+
+        else:
+            df.columns = [col.replace("takes_", "") for col in df.columns]
+            df.columns = [col.replace("_id", "") for col in df.columns]
+
+            # TODO: decide whether we should return the unformatted fields or not
+            if formatted:
+                df = df.drop(
+                    columns=[
+                        "id",
+                    ]
+                )
+                df = df.rename(
+                    columns={
+                        "take_amt_formatted": "take_amt",
+                        "give_amt_formatted": "give_amt",
+                        "take_amt": "take_amt_raw",
+                        "give_amt": "give_amt_raw",
+                        "take_gem": "take_gem_address",
+                        "give_gem": "give_gem_address",
+                        "take_gem_symbol": "take_gem",
+                        "give_gem_symbol": "give_gem",
+                        "index": "log_index",
+                        "transaction_block_number": "block_number",
+                        "transaction_block_index": "block_index",
+                        "offer_transaction_block_number": "offer_block_number",
+                        "offer_transaction_block_index": "offer_block_index",
+                        "offer_index": "offer_log_index",
+                    }
+                )
+                # TODO: we could also get smart with displaying price dependent upon the pair_name and direction of the
+                #  order
+
+        # TODO: apply any data type conversions to the dataframe - possibly converting unformatted values to integers
+        return df

--- a/rubi/tests/fixtures/setup_ethereum_test_environment.py
+++ b/rubi/tests/fixtures/setup_ethereum_test_environment.py
@@ -257,6 +257,7 @@ def test_network(
         rpc_url="https://ishan.io/rpc",
         explorer_url="https://ishanexplorer.io",
         market_data_url="https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev",  # TODO: update once prod has been synced
+        market_data_fallback_url="https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev",
         rubicon=rubicon,
         token_addresses=token_addresses,
     )

--- a/rubi/tests/rubi_tests.py
+++ b/rubi/tests/rubi_tests.py
@@ -8,6 +8,7 @@ from web3 import Web3
 from web3.contract import Contract
 from subgrounds import Subgrounds
 
+from contracts.contract_types.transaction_reciept import TransactionStatus
 from rubi import (
     Network,
     Client,
@@ -219,6 +220,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == market_order.pair
+        assert event.order_side == market_order.order_side
+        assert event.order_type == OrderType.MARKET
+        assert event.size == market_order.size
+        assert event.price == Decimal("2")
+        assert event.market_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -279,6 +293,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == market_order.pair
+        assert event.order_side == market_order.order_side
+        assert event.order_type == OrderType.MARKET
+        assert event.size == market_order.size
+        assert event.price == Decimal("1")
+        assert event.market_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -337,6 +364,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == limit_order.pair
+        assert event.order_side == limit_order.order_side
+        assert event.order_type == OrderType.LIMIT
+        assert event.size == limit_order.size
+        assert event.price == limit_order.price
+        assert event.limit_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -390,6 +430,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == limit_order.pair
+        assert event.order_side == limit_order.order_side
+        assert event.order_type == OrderType.LIMIT
+        assert event.size == limit_order.size
+        assert event.price == limit_order.price
+        assert event.limit_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -444,6 +497,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == limit_order.pair
+        assert event.order_side == limit_order.order_side
+        assert event.order_type == OrderType.MARKET
+        assert event.size == limit_order.size
+        assert event.price == Decimal("2")
+        assert event.market_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -505,6 +571,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == limit_order.pair
+        assert event.order_side == limit_order.order_side
+        assert event.order_type == OrderType.MARKET
+        assert event.size == limit_order.size
+        assert event.price == Decimal("1")
+        assert event.market_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -591,6 +670,19 @@ class TestClient:
 
         # Check that cancel txn was a success
         assert cancel_result.status == 1
+        assert cancel_result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(cancel_result.events) == 1
+
+        event: OrderEvent = cancel_result.events[0]
+
+        assert event.pair_name == cancel_limit_order.pair
+        assert event.order_type == OrderType.CANCEL
+        assert event.order_side == limit_order.order_side
+        assert event.price == limit_order.price
+        assert event.size == limit_order.size
+        assert event.limit_order_owner == test_client_for_account_1.wallet
 
         orderbook_after_cancel = test_client_for_account_1.get_orderbook(
             pair_name=pair_name
@@ -634,6 +726,20 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 2
+
+        for i, limit_order in enumerate([limit_order_1, limit_order_2]):
+            event: OrderEvent = result.events[i]
+
+            assert event.pair_name == limit_order.pair
+            assert event.order_type == OrderType.LIMIT
+            assert event.order_side == limit_order.order_side
+            assert event.price == limit_order.price
+            assert event.size == limit_order.size
+            assert event.limit_order_owner == test_client_for_account_1.wallet
 
         # Check that offers has been placed in the market
         orderbook_after_transaction = test_client_for_account_1.get_orderbook(
@@ -680,6 +786,27 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 4
+
+        for i, limit_order in enumerate([limit_order_1, limit_order_2]):
+            event: OrderEvent = result.events[i]
+
+            assert event.pair_name == limit_order.pair
+            assert event.order_type == OrderType.LIMIT
+            assert event.order_side == limit_order.order_side
+            assert event.price == limit_order.price
+            assert event.size == limit_order.size
+            assert event.limit_order_owner == test_client_for_account_2.wallet
+
+        for i in range(2, 4):
+            event: OrderEvent = result.events[i]
+
+            assert event.pair_name == limit_order_1.pair
+            assert event.order_type == OrderType.CANCEL
+            assert event.limit_order_owner == test_client_for_account_2.wallet
 
         # Check that offers has been placed in the market
         orderbook_after_update = test_client_for_account_2.get_orderbook(
@@ -716,6 +843,17 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 2
+
+        for i, cancel_order in enumerate([cancel_order_1, cancel_order_2]):
+            event: OrderEvent = result.events[i]
+
+            assert event.pair_name == cancel_order.pair
+            assert event.order_type == OrderType.CANCEL
+            assert event.limit_order_owner == test_client_for_account_2.wallet
 
         # Check that offers has been placed in the market
         orderbook_after_transaction = test_client_for_account_2.get_orderbook(

--- a/rubi/tests/test_network_config/test_config.yaml
+++ b/rubi/tests/test_network_config/test_config.yaml
@@ -4,6 +4,7 @@ currency: "ISH"
 rpc_url: "https://ishan.io/rpc"
 explorer_url: "https://ishanexplorer.io"
 market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet"
+market_data_fallback_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet"
 
 rubicon:
  market:


### PR DESCRIPTION
# rubi-py PR

- Note - **please make sure the title of your PR follows semantic versioning** 
- Ex. fix/feat/refactor: description 
- For a breaking change, that will bump an entire version, please use !. Ex. refactor!: description 

## Description

Adds a `DetailedOrderBook` that can be created from a subgraph query that contains detailed information regarding an order book instance and expands the base `OrderBook class




## What was the issue?
the existing order book classed lacked detailed information about the orders that it represented. 




## What were the changes?
within `rubicon_types` and `data/market.py`



## What type of change was this 

- [ ] fix - fixing bugs and adding small changes (X.X.X+1)
- [x] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



