### PR TITLE
fix: graph retry + fallback

### DIFF
--- a/rubi/network_config/abitrum_goerli/network.yaml
+++ b/rubi/network_config/abitrum_goerli/network.yaml
@@ -4,6 +4,7 @@ currency: "ETH"
 rpc_url: "https://goerli-rollup.arbitrum.io/rpc"
 explorer_url: "https://goerli-rollup-explorer.arbitrum.io"
 market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Arbitrum_Goerli"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-arbitrum-goerli"
 
 rubicon:
  market:

--- a/rubi/network_config/optimism/network.yaml
+++ b/rubi/network_config/optimism/network.yaml
@@ -4,6 +4,7 @@ currency: "ETH"
 rpc_url: "https://mainnet.optimism.io"
 explorer_url: "https://optimistic.etherscan.io/"
 market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-optimism-mainnet"
 
 rubicon:
  market:

--- a/rubi/network_config/optimism_goerli/network.yaml
+++ b/rubi/network_config/optimism_goerli/network.yaml
@@ -4,6 +4,7 @@ currency: "ETH"
 rpc_url: "https://goerli.optimism.io"
 explorer_url: "https://goerli-explorer.optimism.io/"
 market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Goerli"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-optimism-goerli"
 
 rubicon:
  market:

--- a/rubi/network_config/polygon_mumbai/network.yaml
+++ b/rubi/network_config/polygon_mumbai/network.yaml
@@ -4,6 +4,7 @@ currency: "MATIC"
 rpc_url: "https://rpc-mumbai.maticvigil.com/"
 explorer_url: "https://mumbai.polygonscan.com/"
 market_data_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-polygon-mumbai"
+market_data_fallback_url: "https://api.thegraph.com/subgraphs/name/denverbaumgartner/rubiconv2-polygon-mumbai"
 
 rubicon:
  market:

--- a/rubi/rubi/data/market.py
+++ b/rubi/rubi/data/market.py
@@ -1,6 +1,5 @@
 from typing import Optional, Dict
 
-import time
 import pandas as pd
 from eth_typing import ChecksumAddress
 from subgrounds import Subgrounds
@@ -54,7 +53,6 @@ class MarketData:
                 break
             except Exception as e:
                 if attempt < 2:
-                    time.sleep(1.5)
                     continue
                 else:
                     try:

--- a/rubi/rubi/data/market.py
+++ b/rubi/rubi/data/market.py
@@ -48,11 +48,13 @@ class MarketData:
         # initialize the subgraph
         for attempt in range(3):
             try:
-                self.data = self.sg.load_subgraph(self.subgraph_url) # TODO: we should add a check here to guarantee the schema matches what we expect to be receiving
-                break 
+                self.data = self.sg.load_subgraph(
+                    self.subgraph_url
+                )  # TODO: we should add a check here to guarantee the schema matches what we expect to be receiving
+                break
             except Exception as e:
-                if attempt < 2: 
-                    time.sleep(1.5) 
+                if attempt < 2:
+                    time.sleep(1.5)
                     continue
                 else:
                     try:

--- a/rubi/rubi/network/network.py
+++ b/rubi/rubi/network/network.py
@@ -36,6 +36,7 @@ class Network:
         rpc_url: str,
         explorer_url: str,
         market_data_url: str,
+        market_data_fallback_url: str,
         rubicon: dict,
         token_addresses: dict,
         # optional custom token config file from the user
@@ -78,6 +79,7 @@ class Network:
         # TODO: currently we are utilizing just a single url, we should switch to a dictionary as the number of
         #  subgraphs we support grows
         self.market_data_url = market_data_url
+        self.market_data_fallback_url = market_data_fallback_url
         self.rubicon = RubiconContracts(path=path, w3=self.w3, **rubicon)
 
         checksummed_token_addresses: dict[str, ChecksumAddress] = {}

--- a/rubi/tests/fixtures/setup_ethereum_test_environment.py
+++ b/rubi/tests/fixtures/setup_ethereum_test_environment.py
@@ -257,7 +257,7 @@ def test_network(
         rpc_url="https://ishan.io/rpc",
         explorer_url="https://ishanexplorer.io",
         market_data_url="https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev",  # TODO: update once prod has been synced
-        market_data_fallback_url="https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev", 
+        market_data_fallback_url="https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev",
         rubicon=rubicon,
         token_addresses=token_addresses,
     )

--- a/rubi/tests/fixtures/setup_ethereum_test_environment.py
+++ b/rubi/tests/fixtures/setup_ethereum_test_environment.py
@@ -257,6 +257,7 @@ def test_network(
         rpc_url="https://ishan.io/rpc",
         explorer_url="https://ishanexplorer.io",
         market_data_url="https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev",  # TODO: update once prod has been synced
+        market_data_fallback_url="https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet_Dev", 
         rubicon=rubicon,
         token_addresses=token_addresses,
     )

--- a/rubi/tests/test_network_config/test_config.yaml
+++ b/rubi/tests/test_network_config/test_config.yaml
@@ -4,6 +4,7 @@ currency: "ISH"
 rpc_url: "https://ishan.io/rpc"
 explorer_url: "https://ishanexplorer.io"
 market_data_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet"
+market_data_fallback_url: "https://api.rubicon.finance/subgraphs/name/RubiconV2_Optimism_Mainnet"
 
 rubicon:
  market:


### PR DESCRIPTION
# rubi-py PR

- Note - **please make sure the title of your PR follows semantic versioning** 
- Ex. fix/feat/refactor: description 
- For a breaking change, that will bump an entire version, please use !. Ex. refactor!: description 

## Description

modifies the `data/market` to attempt to connect to the default subgraph endpoint three times, waiting 1.5 seconds between attempt, before attempting to to connect to the hosted service as a fallback. if all four attempts fail it will throw a value error. 



## What was the issue?

users experiencing connection issues that are most likely a result of networking errors and a desire to make the data layer more resilient to any potential hardware issues



## What were the changes?

- modifies `data/market` to utilize the fallback pattern described above
- modifies `network` to contain a fallback market data url 
- updates `tests` based on `network` updates



## What type of change was this 

- [x] fix - fixing bugs and adding small changes (X.X.X+1)
- [ ] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



