### PR TITLE
fix: gridbot only cares about it's own orders

### DIFF
--- a/bots/example_bots/gridbot.py
+++ b/bots/example_bots/gridbot.py
@@ -63,9 +63,15 @@ class GridBot(BaseEventTradingFramework):
         self.client.start_orderbook_poller(pair_name=self.pair.name)
 
         # Order event pollers
-        self.client.start_event_poller(pair_name=self.pair.name, event_type=EmitOfferEvent)
-        self.client.start_event_poller(pair_name=self.pair.name, event_type=EmitTakeEvent)
-        self.client.start_event_poller(pair_name=self.pair.name, event_type=EmitCancelEvent)
+        self.client.start_event_poller(
+            pair_name=self.pair.name, event_type=EmitOfferEvent, filters={"maker": self.client.wallet}
+        )
+        self.client.start_event_poller(
+            pair_name=self.pair.name, event_type=EmitTakeEvent, filters={"maker": self.client.wallet}
+        )
+        self.client.start_event_poller(
+            pair_name=self.pair.name, event_type=EmitCancelEvent, filters={"maker": self.client.wallet}
+        )
 
         # set allowed_to_place_new_orders to True
         self.allowed_to_place_new_orders = True


### PR DESCRIPTION
# Change event pollers in gridbot to only listen to it's own orders

## Description

Mentioned by Satfield.

Change event pollers in gridbot to only listen to it's own orders by adding 

`filters={"maker": self.client.wallet}`

This is required due to https://github.com/RubiconDeFi/rubi-py/pull/60


## What type of change was this 

- [X] fix - fixing bugs and adding small changes (X.X.X+1)
- [ ] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



