### PR TITLE
feat: add the simulate flag for transactions

### DIFF
--- a/rubi/docs/examples/example_simulate_transaction.py
+++ b/rubi/docs/examples/example_simulate_transaction.py
@@ -1,0 +1,49 @@
+import logging as log
+import os
+from _decimal import Decimal
+from multiprocessing import Queue
+
+from dotenv import load_dotenv
+
+from rubi import Client, NewMarketOrder
+from rubi import EmitOfferEvent, Transaction, NewLimitOrder, OrderSide
+
+# load from env file
+load_dotenv("../../local.env")
+
+# you local.env should look like this:
+# HTTP_NODE_URL={ the url of the node you are using to connect to the network }
+# DEV_WALLET={ your wallet address 0x... }
+# DEV_KEY={ your private key }
+
+# set logging config
+log.basicConfig(level=log.INFO)
+
+# set the env variables
+http_node_url = os.getenv("HTTP_NODE_URL")
+wallet = os.getenv("DEV_WALLET")
+key = os.getenv("DEV_KEY")
+
+# create client
+client = Client.from_http_node_url(
+    http_node_url=http_node_url,
+    wallet=wallet,
+    key=key,
+)
+
+# add the WETH/USDC pair to the client
+client.add_pair(pair_name="WETH/USDC")
+
+# Place a new limit order
+limit_order = NewLimitOrder(
+    pair_name="WETH/USDC",
+    order_side=OrderSide.BUY,
+    size=Decimal("1"),
+    price=Decimal("10"),
+)
+
+transaction = Transaction(orders=[limit_order], simulate=True)
+
+transaction_simulation_result = client.place_limit_order(transaction=transaction)
+
+log.info(transaction_simulation_result)

--- a/rubi/rubi/client.py
+++ b/rubi/rubi/client.py
@@ -15,6 +15,7 @@ from rubi.contracts import (
     ERC20,
     TransactionReceipt,
     EmitFeeEvent,
+    TransactionSimulation,
 )
 from rubi.network import (
     Network,
@@ -457,15 +458,17 @@ class Client:
     # order methods
     ######################################################################
 
-    def place_market_order(self, transaction: Transaction) -> TransactionReceipt:
+    def place_market_order(
+        self, transaction: Transaction
+    ) -> TransactionReceipt | TransactionSimulation:
         """Place a market order transaction by executing the specified transaction object. The transaction
         object should contain a single order of type NewMarketOrder. The order is retrieved from the transaction and
         the corresponding market buy or sell method is called based on the order side.
 
         :param transaction: Transaction object containing the market order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed market order.
-        :rtype: str
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -497,14 +500,16 @@ class Client:
                     **transaction.args(),
                 )
 
-    def place_limit_order(self, transaction: Transaction) -> TransactionReceipt:
+    def place_limit_order(
+        self, transaction: Transaction
+    ) -> TransactionReceipt | TransactionSimulation:
         """Place a limit order transaction by executing the specified transaction object. The transaction object should
         contain a single order of type NewLimitOrder.
 
         :param transaction: Transaction object containing the limit order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed limit order.
-        :rtype: str
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -532,14 +537,16 @@ class Client:
                     **transaction.args(),
                 )
 
-    def cancel_limit_order(self, transaction: Transaction) -> TransactionReceipt:
+    def cancel_limit_order(
+        self, transaction: Transaction
+    ) -> TransactionReceipt | TransactionSimulation:
         """Place a limit order cancel transaction by executing the specified transaction object. The transaction object
         should contain a single order of type NewCancelOrder.
 
         :param transaction: Transaction object containing the cancel order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed cancel order.
-        :rtype: str
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -549,13 +556,15 @@ class Client:
 
         return self.market.cancel(id=order.order_id, **transaction.args())
 
-    def batch_place_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
+    def batch_place_limit_orders(
+        self, transaction: Transaction
+    ) -> TransactionReceipt | TransactionSimulation:
         """Place multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit orders.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit orders.
-        :rtype: str
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         pay_amts = []
         pay_gems = []
@@ -590,13 +599,15 @@ class Client:
             **transaction.args(),
         )
 
-    def batch_update_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
+    def batch_update_limit_orders(
+        self, transaction: Transaction
+    ) -> TransactionReceipt | TransactionSimulation:
         """Update multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit order updates.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit order updates.
-        :rtype: str
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         order_ids = []
         pay_amts = []
@@ -635,13 +646,15 @@ class Client:
             **transaction.args(),
         )
 
-    def batch_cancel_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
+    def batch_cancel_limit_orders(
+        self, transaction: Transaction
+    ) -> TransactionReceipt | TransactionSimulation:
         """Cancel multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit order cancellations.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit order cancellations.
-        :rtype: str
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         order_ids = []
 

--- a/rubi/rubi/contracts/contract_types/__init__.py
+++ b/rubi/rubi/contracts/contract_types/__init__.py
@@ -1,2 +1,2 @@
 from .events import *
-from .transaction_reciept import TransactionReceipt
+from .transaction_reciept import TransactionReceipt, TransactionSimulation

--- a/rubi/rubi/contracts/contract_types/transaction_reciept.py
+++ b/rubi/rubi/contracts/contract_types/transaction_reciept.py
@@ -3,7 +3,23 @@ from typing import Optional
 
 from eth_typing import BlockNumber, ChecksumAddress
 from hexbytes import HexBytes
-from web3.types import Wei, TxReceipt
+from web3.types import Wei, TxReceipt, TxParams
+
+
+class TransactionSimulation:
+    def __init__(
+        self,
+        success: bool,
+        transaction_params: Optional[TxParams] = None,
+        failure_reason: Optional[Exception] = None,
+    ):
+        self.success = success
+        self.transaction_params = transaction_params
+        self.failure_reason = failure_reason
+
+    def __repr__(self):
+        items = ("{}={!r}".format(k, self.__dict__[k]) for k in self.__dict__)
+        return "{}({})".format(type(self).__name__, ", ".join(items))
 
 
 # TODO: a TxReceipt contains logs which can be decoded into events that were emitted by calling the contract function.

--- a/rubi/rubi/contracts/erc20.py
+++ b/rubi/rubi/contracts/erc20.py
@@ -9,7 +9,7 @@ from web3.contract import Contract
 from web3.types import ABI
 
 from rubi.contracts.base_contract import BaseContract
-from rubi.contracts.contract_types import TransactionReceipt
+from rubi.contracts.contract_types import TransactionReceipt, TransactionSimulation
 from rubi.network import Network
 
 
@@ -215,7 +215,8 @@ class ERC20(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Approves the spender to spend the amount of the erc20 token from the signer's wallet
 
         :param spender: address of the spender
@@ -233,8 +234,11 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         approve = self.contract.functions.approve(spender, amount)
 
@@ -244,6 +248,7 @@ class ERC20(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # transfer(recipient (address), amount (uint256)) -> bool
@@ -255,7 +260,8 @@ class ERC20(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Transfers the amount of the erc20 token to the recipient
 
         :param recipient: address of the recipient
@@ -272,8 +278,11 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         transfer = self.contract.functions.transfer(recipient, amount)
 
@@ -283,6 +292,7 @@ class ERC20(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # transferFrom(sender (address), recipient (address), amount (uint256)) -> bool
@@ -295,7 +305,8 @@ class ERC20(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Transfers the amount of the erc20 token from the sender to the recipient
 
         :param sender: address of the sender
@@ -315,8 +326,11 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
 
         transfer_from = self.contract.functions.transferFrom(sender, recipient, amount)
@@ -327,6 +341,7 @@ class ERC20(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # increaseAllowance(spender (address), addedValue (uint256)) -> bool
@@ -338,7 +353,8 @@ class ERC20(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Increases the allowance of the spender by the added_value
 
         :param spender: address of the spender
@@ -356,8 +372,11 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         increase_allowance = self.contract.functions.increaseAllowance(
             spender, added_value
@@ -369,6 +388,7 @@ class ERC20(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # decreaseAllowance(spender (address), subtractedValue (uint256)) -> bool
@@ -380,7 +400,8 @@ class ERC20(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Decreases the allowance of the spender by the subtracted_value
 
         :param spender: address of the spender
@@ -398,8 +419,11 @@ class ERC20(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         decrease_allowance = self.contract.functions.decreaseAllowance(
             spender, subtracted_value
@@ -411,6 +435,7 @@ class ERC20(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     ######################################################################

--- a/rubi/rubi/contracts/market.py
+++ b/rubi/rubi/contracts/market.py
@@ -5,7 +5,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from rubi.contracts.base_contract import BaseContract
-from rubi.contracts.contract_types import TransactionReceipt
+from rubi.contracts.contract_types import TransactionReceipt, TransactionSimulation
 from rubi.network import Network
 
 
@@ -227,7 +227,8 @@ class RubiconMarket(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Make a new offer to buy the buy_amt of the buy_gem token in exchange for the pay_amt of the pay_gem token
 
         :param pay_amt: the amount of the token being sold
@@ -260,8 +261,11 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
 
         if not self.signing_permissions:
@@ -283,6 +287,7 @@ class RubiconMarket(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # cancel(id (uint256)) -> bool
@@ -293,7 +298,8 @@ class RubiconMarket(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Cancel an offer by offer id
 
         :param id: the id of the offer to cancel
@@ -309,8 +315,11 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
 
         cancel = self.contract.functions.cancel(id)
@@ -321,6 +330,7 @@ class RubiconMarket(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # batchOffer(payAmts (uint[]), payGems (address[]), buyAmts (uint[]), buyGems (address[])) -> uint256[]
@@ -334,7 +344,8 @@ class RubiconMarket(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Batch the placement of a set of offers in one transaction
 
         :param pay_amts: the amounts of the token being sold
@@ -356,8 +367,11 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         if not (len(pay_amts) == len(pay_gems) == len(buy_amts) == len(buy_gems)):
             raise Exception(
@@ -374,6 +388,7 @@ class RubiconMarket(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # batchCancel (ids (uint256[])) -> bool[]
@@ -384,7 +399,8 @@ class RubiconMarket(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Cancel a set offer by offer id in a single transaction
 
         :param ids: the ids of the offers to cancel
@@ -400,8 +416,11 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         cancels = self.contract.functions.batchCancel(ids)
 
@@ -411,6 +430,7 @@ class RubiconMarket(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # batchRequote (ids (uint256[]), payAmts (uint[]), payGems (address[]), buyAmts (uint[]), buyGems (address[]))
@@ -426,7 +446,8 @@ class RubiconMarket(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Batch update a set of offers in a single transaction and return a list of new offer ids
 
         :param ids: the ids of the offers to cancel
@@ -450,8 +471,11 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
 
         batch_requote = self.contract.functions.batchRequote(
@@ -464,6 +488,7 @@ class RubiconMarket(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # sellAllAmount(pay_gem (address), pay_amt (uint256), buy_gem (address), min_fill_amount (uint256)) -> uint256
@@ -477,7 +502,8 @@ class RubiconMarket(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Sell the pay_amt of the pay_gem token in exchange for buy_gem, on the condition that you receive at least the
         min_fill_amount of the buy_gem token
 
@@ -500,8 +526,14 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         sell_all_amount = self.contract.functions.sellAllAmount(
             pay_gem, pay_amt, buy_gem, min_fill_amount
@@ -513,6 +545,7 @@ class RubiconMarket(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # buyAllAmount(buy_gem (address), buy_amt (uint256), pay_gem (address), max_fill_amount (uint256)) -> uint256
@@ -526,7 +559,8 @@ class RubiconMarket(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Buy the buy_amt of the buy_gem token in exchange for pay_gem, on the condition that it does not exceed the
         max_fill_amount of the pay_gem token
 
@@ -549,8 +583,11 @@ class RubiconMarket(BaseContract):
         :param max_priority_fee_per_gas: max priority fee that can be paid for gas, defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None)
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
         buy_all_amount = self.contract.functions.buyAllAmount(
             buy_gem, buy_amt, pay_gem, max_fill_amount
@@ -562,4 +599,5 @@ class RubiconMarket(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )

--- a/rubi/rubi/contracts/router.py
+++ b/rubi/rubi/contracts/router.py
@@ -5,7 +5,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from rubi.contracts.base_contract import BaseContract
-from rubi.contracts.contract_types import TransactionReceipt
+from rubi.contracts.contract_types import TransactionReceipt, TransactionSimulation
 from rubi.network import Network
 
 
@@ -246,7 +246,8 @@ class RubiconRouter(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Perform a multiple swaps for the specified payment amounts using the specified routes. Reverts with an
         exception if any of the swaps cannot achieve the buy_amt_min along the specified route.
 
@@ -269,8 +270,11 @@ class RubiconRouter(BaseContract):
         :param max_priority_fee_per_gas: Max priority fee that can be paid for gas. Defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None).
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
 
         multiswap = self.contract.functions.multiswap(
@@ -283,6 +287,7 @@ class RubiconRouter(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # swap(uint256 pay_amt, uint256 buy_amt_min, address[] memory route, address to) -> uint256
@@ -296,7 +301,8 @@ class RubiconRouter(BaseContract):
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
-    ) -> TransactionReceipt:
+        simulate: bool = False,
+    ) -> TransactionReceipt | TransactionSimulation:
         """Perform a swap operation with the specified payment amount using the specified route and paying out to the
         recipient. Reverts if the swap does not result in the buy_min_amount.
 
@@ -319,8 +325,11 @@ class RubiconRouter(BaseContract):
         :param max_priority_fee_per_gas: Max priority fee that can be paid for gas. Defaults to calling the chain to
             estimate the max_priority_fee_per_gas (optional, default is None).
         :type max_priority_fee_per_gas: Optional[int]
-        :return: An object representing the transaction receipt
-        :rtype: TransactionReceipt
+        :param simulate: If true then does not send the transaction to chain but rather simulates the transaction and
+            returns the result along with estimates if they are not provided. (defaults to False)
+        :type simulate: bool
+        :return: An object representing the transaction receipt or transaction simulation
+        :rtype: TransactionReceipt | TransactionSimulation
         """
 
         swap = self.contract.functions.swap(pay_amt, buy_amt_min, route, to)
@@ -331,6 +340,7 @@ class RubiconRouter(BaseContract):
             nonce=nonce,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
+            simulate=simulate,
         )
 
     # TODO

--- a/rubi/rubi/rubicon_types/order.py
+++ b/rubi/rubi/rubicon_types/order.py
@@ -219,6 +219,7 @@ class Transaction:
         gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
+        simulate: bool = False,
     ):
         """constructor method"""
         if len(orders) < 1:
@@ -231,6 +232,7 @@ class Transaction:
         self.gas = gas
         self.max_fee_per_gas = max_fee_per_gas
         self.max_priority_fee_per_gas = max_priority_fee_per_gas
+        self.simulate = simulate
 
     def args(self) -> Dict:
         """Creates a dictionary of not None arguments to pass to contract functions.
@@ -243,6 +245,7 @@ class Transaction:
             "gas": self.gas,
             "max_fee_per_gas": self.max_fee_per_gas,
             "max_priority_fee_per_gas": self.max_priority_fee_per_gas,
+            "simulate": self.simulate,
         }
 
         return {key: value for key, value in args.items() if value is not None}


### PR DESCRIPTION
## Description

Add the simulate flag for transactions on all on chain calls so that they can be simulated before being sent. Included the TransactionSimulation object as a return type.

Note: Still want to fetch the l1 gas price and l1 scalar so that transaction costs can be properly calculated

## What was the issue?

https://github.com/RubiconDeFi/rubi-py/issues/64

## What type of change was this 

- [ ] fix - fixing bugs and adding small changes (X.X.X+1)
- [X] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



