### PR TITLE
fix: rounding default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ bot_config.yaml
 
 #mac files
 .DS_store
+
+# playground
+playground.py

--- a/rubi/rubi/contracts/market.py
+++ b/rubi/rubi/contracts/market.py
@@ -220,7 +220,7 @@ class RubiconMarket(BaseContract):
         buy_amt: int,
         buy_gem: ChecksumAddress,
         pos: int = 0,
-        rounding: bool = True,
+        rounding: bool = False,
         owner: Optional[ChecksumAddress] = None,
         recipient: Optional[ChecksumAddress] = None,
         nonce: Optional[int] = None,
@@ -241,7 +241,7 @@ class RubiconMarket(BaseContract):
         :param pos: position of the offer in the linked list, default to 0 unless the maker knows the position they want
             to insert the offer at
         :type pos: int
-        :param rounding: add rounding to match "close enough" orders, defaults to True
+        :param rounding: add rounding to match "close enough" orders, defaults to False
         :type: rounding: bool
         :param owner: the owner of the offer, defaults to the wallet that was provided in instantiating this class.
             (optional, default is None)

--- a/rubi/rubi/rubicon_types/order.py
+++ b/rubi/rubi/rubicon_types/order.py
@@ -37,6 +37,17 @@ class OrderSide(Enum):
             case OrderSide.SELL:
                 return -1
 
+    def opposite(self) -> "OrderSide":
+        match self:
+            case OrderSide.NEUTRAL:
+                return OrderSide.NEUTRAL
+
+            case OrderSide.BUY:
+                return OrderSide.SELL
+
+            case OrderSide.SELL:
+                return OrderSide.BUY
+
 
 class OrderType(Enum):
     """Enumeration representing the order type."""
@@ -136,6 +147,10 @@ class NewLimitOrder(BaseNewOrder):
 
         self.size = size
         self.price = price
+
+    def __repr__(self):
+        items = ("{}={!r}".format(k, self.__dict__[k]) for k in self.__dict__)
+        return "{}({})".format(type(self).__name__, ", ".join(items))
 
 
 class UpdateLimitOrder(BaseNewOrder):


### PR DESCRIPTION
# rubi-py PR

## Description

Default rounding to false.
Added OrderSide opposite function.

## What was the issue?

Relates to: https://github.com/RubiconDeFi/rubi-py/issues/69

## What type of change was this 

- [X] fix - fixing bugs and adding small changes (X.X.X+1)
- [ ] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



