### PR TITLE
fix: add consecutive_failure_count to catch deathloops.

### DIFF
--- a/bots/example_bots/gridbot.py
+++ b/bots/example_bots/gridbot.py
@@ -144,6 +144,8 @@ class GridBot(BaseEventTradingFramework):
                 log.warning(f"Failed transaction: {result.transaction_receipt.transaction_hash.hex()}, "
                             f"with nonce: {result.nonce}")
 
+        del self.pending_transactions[result.nonce]
+
         if self.consecutive_failure_count >= 5:
             self.allowed_to_place_new_orders = False
             self.running = False


### PR DESCRIPTION
# Fix: catch deathloop

## Description

I have not been able to replicate but the Satfield guys ran into a deathloop where the bot spent all their gas. To that end I have added a `consecutive_failure_count` to catch and prevent this from occuring.

## What type of change was this 

- [X] fix - fixing bugs and adding small changes (X.X.X+1)
- [ ] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



