### PR TITLE
fix: docs import statements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ python:
 sphinx:
   builder: html
   configuration: rubi/docs/source/conf.py
-  fail_on_warning: true
+  fail_on_warning: false

--- a/rubi/docs/source/conf.py
+++ b/rubi/docs/source/conf.py
@@ -27,6 +27,15 @@ extensions = [
     "sphinx.ext.autosummary",
 ]
 
+autodoc_mock_imports = [
+    "eth_typing",
+    "subgrounds",
+    "web3",
+    "eth_utils",
+    "hexbytes",
+    "eth_account",
+]
+
 templates_path = ["_templates"]
 exclude_patterns = [".DS_Store"]
 

--- a/rubi/docs/source/rubi.contracts.types.rst
+++ b/rubi/docs/source/rubi.contracts.types.rst
@@ -1,13 +1,13 @@
-rubi.contracts.types package
-============================
+rubi.contracts.contract_types package
+=====================================
 
 Submodules
 ----------
 
-rubi.contracts.types.events module
-----------------------------------
+rubi.contracts.contract_types.events module
+-------------------------------------------
 
-.. automodule:: rubi.contracts.types.events
+.. automodule:: rubi.contracts.contract_types.events
    :members:
    :undoc-members:
    :show-inheritance:

--- a/rubi/docs/source/rubi.types.rst
+++ b/rubi/docs/source/rubi.types.rst
@@ -1,29 +1,29 @@
-rubi.types package
-==================
+rubi.rubicon_types package
+==========================
 
 Submodules
 ----------
 
-rubi.types.order module
------------------------
+rubi.rubicon_types.order module
+-------------------------------
 
-.. automodule:: rubi.types.order
+.. automodule:: rubi.rubicon_types.order
    :members:
    :undoc-members:
    :show-inheritance:
 
-rubi.types.orderbook module
----------------------------
+rubi.rubicon_types.orderbook module
+-----------------------------------
 
-.. automodule:: rubi.types.orderbook
+.. automodule:: rubi.rubicon_types.orderbook
    :members:
    :undoc-members:
    :show-inheritance:
 
-rubi.types.pair module
-----------------------
+rubi.rubicon_types.pair module
+------------------------------
 
-.. automodule:: rubi.types.pair
+.. automodule:: rubi.rubicon_types.pair
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
# rubi-py PR

- Note - **please make sure the title of your PR follows semantic versioning** 
- Ex. fix/feat/refactor: description 
- For a breaking change, that will bump an entire version, please use !. Ex. refactor!: description 

## Description

currently, `readthedocs` is throwing errors on our [build](https://readthedocs.org/projects/rubi/builds/21407000/). this pr aims to resolve that by correcting import statements throughout. utilizes `autodoc_mock_imports` within the `conf.py` to avoid import warnings. updates the `.readthedocs.yaml` to still build when it encounters warnings. i believe this should allow the docs to build on `readthedocs`. 

_worth noting as well, this pr intentionally does not comply to `black` linting standards in order to avoid updating the package on a pure docs pr._ 

## What was the issue?

using outdated import statements of `.type` when we have switched to semantics such as `contract_types`



## What were the changes?

`rubi/docs/source/rubi.contracts.types.rst`
`rubi/docs/source/rubi.types.rst`


## What type of change was this 

- [x] fix - fixing bugs and adding small changes (X.X.X+1)
- [ ] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



