### PR TITLE
feat: add events to transaction receipt.

### DIFF
--- a/rubi/docs/examples/example.py
+++ b/rubi/docs/examples/example.py
@@ -61,6 +61,14 @@ transaction_result = client.place_limit_order(
 
 log.info(transaction_result)
 
+# Get the offer id from the transaction result
+events = transaction_result.raw_events
+for event in events:
+    if isinstance(event, EmitOfferEvent):
+        offer_id = event.id
+
+log.info(offer_id)
+
 # Print events and order books
 while True:
     message = queue.get()

--- a/rubi/rubi/client.py
+++ b/rubi/rubi/client.py
@@ -3,7 +3,7 @@ from _decimal import Decimal
 from multiprocessing import Queue
 from threading import Thread
 from time import sleep
-from typing import Union, List, Optional, Dict, Type, Any, Callable, TypedDict
+from typing import Union, List, Optional, Dict, Type, Any, Callable
 
 import pandas as pd
 from eth_typing import ChecksumAddress

--- a/rubi/rubi/client.py
+++ b/rubi/rubi/client.py
@@ -3,7 +3,7 @@ from _decimal import Decimal
 from multiprocessing import Queue
 from threading import Thread
 from time import sleep
-from typing import Union, List, Optional, Dict, Type, Any, Callable
+from typing import Union, List, Optional, Dict, Type, Any, Callable, TypedDict
 
 import pandas as pd
 from eth_typing import ChecksumAddress
@@ -15,7 +15,12 @@ from rubi.contracts import (
     ERC20,
     TransactionReceipt,
     EmitFeeEvent,
+    EmitSwap,
+    EmitOfferEvent,
+    EmitTakeEvent,
+    EmitCancelEvent,
 )
+from rubi.data import MarketData
 from rubi.network import (
     Network,
 )
@@ -34,8 +39,6 @@ from rubi.rubicon_types import (
     NewCancelOrder,
     UpdateLimitOrder,
 )
-
-from rubi.data import MarketData
 
 
 class Client:
@@ -464,8 +467,8 @@ class Client:
 
         :param transaction: Transaction object containing the market order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed market order.
-        :rtype: str
+        :return: The transaction receipt of the executed market order.
+        :rtype: TransactionReceipt
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -477,7 +480,7 @@ class Client:
 
         match order.order_side:
             case OrderSide.BUY:
-                return self.market.buy_all_amount(
+                transaction_receipt = self.market.buy_all_amount(
                     buy_gem=pair.base_asset.address,
                     buy_amt=pair.base_asset.to_integer(order.size),
                     pay_gem=pair.quote_asset.address,
@@ -487,7 +490,7 @@ class Client:
                     **transaction.args(),
                 )
             case OrderSide.SELL:
-                return self.market.sell_all_amount(
+                transaction_receipt = self.market.sell_all_amount(
                     pay_gem=pair.base_asset.address,
                     pay_amt=pair.base_asset.to_integer(order.size),
                     buy_gem=pair.quote_asset.address,
@@ -496,6 +499,10 @@ class Client:
                     ),
                     **transaction.args(),
                 )
+            case _:
+                raise Exception("OrderSide must be BUY or SELL")
+
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
 
     def place_limit_order(self, transaction: Transaction) -> TransactionReceipt:
         """Place a limit order transaction by executing the specified transaction object. The transaction object should
@@ -503,8 +510,8 @@ class Client:
 
         :param transaction: Transaction object containing the limit order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed limit order.
-        :rtype: str
+        :return: The transaction receipt of the executed limit order.
+        :rtype: TransactionReceipt
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -516,7 +523,7 @@ class Client:
 
         match order.order_side:
             case OrderSide.BUY:
-                return self.market.offer(
+                transaction_receipt = self.market.offer(
                     pay_amt=pair.quote_asset.to_integer(order.price * order.size),
                     pay_gem=pair.quote_asset.address,
                     buy_amt=pair.base_asset.to_integer(order.size),
@@ -524,13 +531,17 @@ class Client:
                     **transaction.args(),
                 )
             case OrderSide.SELL:
-                return self.market.offer(
+                transaction_receipt = self.market.offer(
                     pay_amt=pair.base_asset.to_integer(order.size),
                     pay_gem=pair.base_asset.address,
                     buy_amt=pair.quote_asset.to_integer(order.price * order.size),
                     buy_gem=pair.quote_asset.address,
                     **transaction.args(),
                 )
+            case _:
+                raise Exception("OrderSide must be BUY or SELL")
+
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
 
     def cancel_limit_order(self, transaction: Transaction) -> TransactionReceipt:
         """Place a limit order cancel transaction by executing the specified transaction object. The transaction object
@@ -538,8 +549,8 @@ class Client:
 
         :param transaction: Transaction object containing the cancel order.
         :type transaction: Transaction
-        :return: The transaction hash of the executed cancel order.
-        :rtype: str
+        :return: The transaction receipt of the executed cancel order.
+        :rtype: TransactionReceipt
         :raises Exception: If the transaction contains more than one order.
         """
         if len(transaction.orders) > 1:
@@ -547,15 +558,19 @@ class Client:
 
         order: NewCancelOrder = transaction.orders[0]  # noqa
 
-        return self.market.cancel(id=order.order_id, **transaction.args())
+        transaction_receipt = self.market.cancel(
+            id=order.order_id, **transaction.args()
+        )
+
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
 
     def batch_place_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Place multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit orders.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit orders.
-        :rtype: str
+        :return: The transaction receipt of the executed batch limit orders.
+        :rtype: TransactionReceipt
         """
         pay_amts = []
         pay_gems = []
@@ -582,7 +597,7 @@ class Client:
                     )
                     buy_gems.append(pair.quote_asset.address)
 
-        return self.market.batch_offer(
+        transaction_receipt = self.market.batch_offer(
             pay_amts=pay_amts,
             pay_gems=pay_gems,
             buy_amts=buy_amts,
@@ -590,13 +605,15 @@ class Client:
             **transaction.args(),
         )
 
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
+
     def batch_update_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Update multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit order updates.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit order updates.
-        :rtype: str
+        :return: The transaction receipt of the executed batch limit order updates.
+        :rtype: TransactionReceipt
         """
         order_ids = []
         pay_amts = []
@@ -626,7 +643,7 @@ class Client:
                     )
                     buy_gems.append(pair.quote_asset.address)
 
-        return self.market.batch_requote(
+        transaction_receipt = self.market.batch_requote(
             ids=order_ids,
             pay_amts=pay_amts,
             pay_gems=pay_gems,
@@ -635,13 +652,15 @@ class Client:
             **transaction.args(),
         )
 
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
+
     def batch_cancel_limit_orders(self, transaction: Transaction) -> TransactionReceipt:
         """Cancel multiple limit orders in a batch transaction.
 
         :param transaction: Transaction object containing multiple limit order cancellations.
         :type transaction: Transaction
-        :return: The transaction hash of the executed batch limit order cancellations.
-        :rtype: str
+        :return: The transaction receipt of the executed batch limit order cancellations.
+        :rtype: TransactionReceipt
         """
         order_ids = []
 
@@ -650,10 +669,14 @@ class Client:
 
             order_ids.append(order.order_id)
 
-        return self.market.batch_cancel(ids=order_ids, **transaction.args())
+        transaction_receipt = self.market.batch_cancel(
+            ids=order_ids, **transaction.args()
+        )
+
+        return self._handle_transaction_receipt_raw_events(transaction_receipt)
 
     ######################################################################
-    # data methods 
+    # data methods
     ######################################################################
 
     # TODO: i would like to remove pay_gem and buy_gem and follow the same pattern as the get_trades method but do not want to cause breaking changes
@@ -766,3 +789,49 @@ class Client:
     @staticmethod
     def _check_allowance(pair: Pair, order: BaseNewOrder):
         pass
+
+    def _handle_transaction_receipt_raw_events(
+        self, transaction_receipt: TransactionReceipt
+    ) -> TransactionReceipt:
+        """
+        Transforms the raw transaction receipt events to human-readable events
+
+        :param transaction_receipt:
+        :type transaction_receipt: TransactionReceipt
+        :return: The transaction receipt with human-readable events populated
+        :rtype: TransactionReceipt
+        """
+        events: List[OrderEvent] = []
+        for raw_event in transaction_receipt.raw_events:
+            if (
+                isinstance(raw_event, EmitFeeEvent)
+                or isinstance(raw_event, EmitSwap)
+                or isinstance(raw_event, Dict)
+            ):
+                # TODO: handle these events correctly
+                continue
+            else:
+                raw_event: Union[EmitOfferEvent, EmitTakeEvent, EmitCancelEvent]
+
+                event_pair = None
+                for pair in self._pairs.values():
+                    if (
+                        pair.ask_identifier == raw_event.pair
+                        or pair.bid_identifier == raw_event.pair
+                    ):
+                        event_pair = pair
+                        break
+
+                if not event_pair:
+                    # We don't have a pair setup to correctly decode this event
+                    continue
+
+                events.append(
+                    OrderEvent.from_event(
+                        pair=event_pair, event=raw_event, wallet=self.wallet
+                    )
+                )
+
+        transaction_receipt.set_events(events=events)
+
+        return transaction_receipt

--- a/rubi/rubi/contracts/contract_types/events.py
+++ b/rubi/rubi/contracts/contract_types/events.py
@@ -161,7 +161,7 @@ class EmitOfferEvent(BaseMarketEvent):
         buy_gem: ChecksumAddress,
         pay_amt: int,
         buy_amt: int,
-        **args
+        **args,
     ):
         """Initialize an EmitOfferEvent instance.
 
@@ -213,7 +213,7 @@ class EmitTakeEvent(BaseMarketEvent):
         buy_gem: ChecksumAddress,
         take_amt: int,
         give_amt: int,
-        **args
+        **args,
     ):
         """Initialize an EmitTakeEvent instance.
 
@@ -272,7 +272,7 @@ class EmitCancelEvent(BaseMarketEvent):
         buy_gem: ChecksumAddress,
         pay_amt: int,
         buy_amt: int,
-        **args
+        **args,
     ):
         """Initialize an EmitCancelEvent instance.
 
@@ -323,7 +323,7 @@ class EmitFeeEvent(BaseMarketEvent):
         feeTo: ChecksumAddress,
         asset: ChecksumAddress,
         feeAmt: int,
-        **args
+        **args,
     ):
         """Initialize an EmitFeeEvent instance.
 
@@ -413,7 +413,7 @@ class EmitSwap(BaseEvent):
         inputAmount: int,
         realizedFill: int,
         hurdleBuyAmtMin: int,
-        **args
+        **args,
     ):
         """Initialize an EmitSwap instance.
 

--- a/rubi/rubi/contracts/contract_types/events.py
+++ b/rubi/rubi/contracts/contract_types/events.py
@@ -27,6 +27,20 @@ class BaseEvent(ABC):
         self.block_number = block_number
 
     @staticmethod
+    def builder(
+        name: str, **kwargs
+    ) -> Union["EmitOfferEvent", "EmitTakeEvent", "EmitCancelEvent", "EmitSwap"]:
+        match name:
+            case "emitOffer":
+                return EmitOfferEvent(**kwargs)
+            case "emitTake":
+                return EmitTakeEvent(**kwargs)
+            case "emitCancel":
+                return EmitCancelEvent(**kwargs)
+            case "emitSwap":
+                return EmitSwap(**kwargs)
+
+    @staticmethod
     @abstractmethod
     def get_event_contract(
         market: _RubiconMarket, router: _RubiconRouter

--- a/rubi/rubi/contracts/erc20.py
+++ b/rubi/rubi/contracts/erc20.py
@@ -8,7 +8,7 @@ from web3 import Web3
 from web3.contract import Contract
 from web3.types import ABI
 
-from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.base_contract import BaseContract, ContractType
 from rubi.contracts.contract_types import TransactionReceipt
 from rubi.network import Network
 
@@ -31,11 +31,18 @@ class ERC20(BaseContract):
         self,
         w3: Web3,
         contract: Contract,
+        contract_type: ContractType = ContractType.ERC20,
         wallet: Optional[ChecksumAddress] = None,
         key: Optional[str] = None,
     ):
         """constructor method"""
-        super().__init__(w3=w3, contract=contract, wallet=wallet, key=key)
+        super().__init__(
+            w3=w3,
+            contract=contract,
+            contract_type=ContractType.ERC20,
+            wallet=wallet,
+            key=key,
+        )
 
         self.name: str = self.name()
         self.symbol: str = self.symbol()
@@ -87,6 +94,7 @@ class ERC20(BaseContract):
             w3=network.w3,
             address=network.token_addresses[name],
             contract_abi=abi,
+            contract_type=ContractType.ERC20,
             wallet=wallet,
             key=key,
         )
@@ -127,7 +135,12 @@ class ERC20(BaseContract):
             )
 
         return cls.from_address_and_abi(
-            w3=w3, address=address, contract_abi=abi, wallet=wallet, key=key
+            w3=w3,
+            address=address,
+            contract_abi=abi,
+            contract_type=ContractType.ERC20,
+            wallet=wallet,
+            key=key,
         )
 
     ######################################################################

--- a/rubi/rubi/contracts/market.py
+++ b/rubi/rubi/contracts/market.py
@@ -4,7 +4,7 @@ from eth_typing import ChecksumAddress
 from web3 import Web3
 from web3.contract import Contract
 
-from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.base_contract import BaseContract, ContractType
 from rubi.contracts.contract_types import TransactionReceipt
 from rubi.network import Network
 
@@ -27,11 +27,18 @@ class RubiconMarket(BaseContract):
         self,
         w3: Web3,
         contract: Contract,
+        contract_type: ContractType = ContractType.RUBICON_MARKET,
         wallet: Optional[ChecksumAddress] = None,
         key: Optional[str] = None,
     ) -> None:
         """constructor method"""
-        super().__init__(w3=w3, contract=contract, wallet=wallet, key=key)
+        super().__init__(
+            w3=w3,
+            contract=contract,
+            contract_type=ContractType.RUBICON_MARKET,
+            wallet=wallet,
+            key=key,
+        )
 
     @classmethod
     def from_network(
@@ -55,6 +62,7 @@ class RubiconMarket(BaseContract):
             w3=network.w3,
             address=network.rubicon.market.address,
             contract_abi=network.rubicon.market.abi,
+            contract_type=ContractType.RUBICON_MARKET,
             wallet=wallet,
             key=key,
         )

--- a/rubi/rubi/contracts/router.py
+++ b/rubi/rubi/contracts/router.py
@@ -4,7 +4,7 @@ from eth_typing import ChecksumAddress
 from web3 import Web3
 from web3.contract import Contract
 
-from rubi.contracts.base_contract import BaseContract
+from rubi.contracts.base_contract import BaseContract, ContractType
 from rubi.contracts.contract_types import TransactionReceipt
 from rubi.network import Network
 
@@ -27,11 +27,18 @@ class RubiconRouter(BaseContract):
         self,
         w3: Web3,
         contract: Contract,
+        contract_type: ContractType = ContractType.RUBICON_ROUTER,
         wallet: Optional[ChecksumAddress] = None,
         key: Optional[str] = None,
     ) -> None:
         """constructor method"""
-        super().__init__(w3=w3, contract=contract, wallet=wallet, key=key)
+        super().__init__(
+            w3=w3,
+            contract=contract,
+            contract_type=ContractType.RUBICON_ROUTER,
+            wallet=wallet,
+            key=key,
+        )
 
     @classmethod
     def from_network(
@@ -55,6 +62,7 @@ class RubiconRouter(BaseContract):
             w3=network.w3,
             address=network.rubicon.router.address,
             contract_abi=network.rubicon.router.abi,
+            contract_type=ContractType.RUBICON_ROUTER,
             wallet=wallet,
             key=key,
         )

--- a/rubi/tests/rubi_tests.py
+++ b/rubi/tests/rubi_tests.py
@@ -8,6 +8,7 @@ from web3 import Web3
 from web3.contract import Contract
 from subgrounds import Subgrounds
 
+from contracts.contract_types.transaction_reciept import TransactionStatus
 from rubi import (
     Network,
     Client,
@@ -219,6 +220,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == market_order.pair
+        assert event.order_side == market_order.order_side
+        assert event.order_type == OrderType.MARKET
+        assert event.size == market_order.size
+        assert event.price == Decimal("2")
+        assert event.market_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -279,6 +293,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == market_order.pair
+        assert event.order_side == market_order.order_side
+        assert event.order_type == OrderType.MARKET
+        assert event.size == market_order.size
+        assert event.price == Decimal("1")
+        assert event.market_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -337,6 +364,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == limit_order.pair
+        assert event.order_side == limit_order.order_side
+        assert event.order_type == OrderType.LIMIT
+        assert event.size == limit_order.size
+        assert event.price == limit_order.price
+        assert event.limit_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -390,6 +430,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == limit_order.pair
+        assert event.order_side == limit_order.order_side
+        assert event.order_type == OrderType.LIMIT
+        assert event.size == limit_order.size
+        assert event.price == limit_order.price
+        assert event.limit_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -444,6 +497,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == limit_order.pair
+        assert event.order_side == limit_order.order_side
+        assert event.order_type == OrderType.MARKET
+        assert event.size == limit_order.size
+        assert event.price == Decimal("2")
+        assert event.market_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -505,6 +571,19 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 1
+
+        event: OrderEvent = result.events[0]
+
+        assert event.pair_name == limit_order.pair
+        assert event.order_side == limit_order.order_side
+        assert event.order_type == OrderType.MARKET
+        assert event.size == limit_order.size
+        assert event.price == Decimal("1")
+        assert event.market_order_owner == test_client_for_account_1.wallet
 
         cow_amount_after_order = cow_erc20_for_account_1.balance_of(
             cow_erc20_for_account_1.wallet
@@ -591,6 +670,19 @@ class TestClient:
 
         # Check that cancel txn was a success
         assert cancel_result.status == 1
+        assert cancel_result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(cancel_result.events) == 1
+
+        event: OrderEvent = cancel_result.events[0]
+
+        assert event.pair_name == cancel_limit_order.pair
+        assert event.order_type == OrderType.CANCEL
+        assert event.order_side == limit_order.order_side
+        assert event.price == limit_order.price
+        assert event.size == limit_order.size
+        assert event.limit_order_owner == test_client_for_account_1.wallet
 
         orderbook_after_cancel = test_client_for_account_1.get_orderbook(
             pair_name=pair_name
@@ -634,6 +726,20 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 2
+
+        for i, limit_order in enumerate([limit_order_1, limit_order_2]):
+            event: OrderEvent = result.events[i]
+
+            assert event.pair_name == limit_order.pair
+            assert event.order_type == OrderType.LIMIT
+            assert event.order_side == limit_order.order_side
+            assert event.price == limit_order.price
+            assert event.size == limit_order.size
+            assert event.limit_order_owner == test_client_for_account_1.wallet
 
         # Check that offers has been placed in the market
         orderbook_after_transaction = test_client_for_account_1.get_orderbook(
@@ -680,6 +786,27 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 4
+
+        for i, limit_order in enumerate([limit_order_1, limit_order_2]):
+            event: OrderEvent = result.events[i]
+
+            assert event.pair_name == limit_order.pair
+            assert event.order_type == OrderType.LIMIT
+            assert event.order_side == limit_order.order_side
+            assert event.price == limit_order.price
+            assert event.size == limit_order.size
+            assert event.limit_order_owner == test_client_for_account_2.wallet
+
+        for i in range(2, 4):
+            event: OrderEvent = result.events[i]
+
+            assert event.pair_name == limit_order_1.pair
+            assert event.order_type == OrderType.CANCEL
+            assert event.limit_order_owner == test_client_for_account_2.wallet
 
         # Check that offers has been placed in the market
         orderbook_after_update = test_client_for_account_2.get_orderbook(
@@ -716,6 +843,17 @@ class TestClient:
 
         # Check that transaction was a success
         assert result.status == 1
+        assert result.transaction_status == TransactionStatus.SUCCESS
+
+        # Check that we received the event we expected
+        assert len(result.events) == 2
+
+        for i, cancel_order in enumerate([cancel_order_1, cancel_order_2]):
+            event: OrderEvent = result.events[i]
+
+            assert event.pair_name == cancel_order.pair
+            assert event.order_type == OrderType.CANCEL
+            assert event.limit_order_owner == test_client_for_account_2.wallet
 
         # Check that offers has been placed in the market
         orderbook_after_transaction = test_client_for_account_2.get_orderbook(


### PR DESCRIPTION
# Add log events to transaction receipt.

## Description

This PR interprets the logs on the `TxReceipt` and then passes back both `raw_events` and `events`(human-readable) to the client. 

Also added the `TransactionStatus` Enum.

Additionally updated tests inline with the above changes. All tests now check that the expected events are received.

## What was the issue?

Closes https://github.com/RubiconDeFi/rubi-py/issues/79

## What type of change was this 

- [ ] fix - fixing bugs and adding small changes (X.X.X+1)
- [X] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



