### PR TITLE
fix: IndexError: list index out of range when constructing orderbook.

### DIFF
--- a/rubi/rubi/rubicon_types/orderbook.py
+++ b/rubi/rubi/rubicon_types/orderbook.py
@@ -84,7 +84,7 @@ class BookSide:
                     size = base_asset.to_decimal(order[0])
                     price = quote_asset.to_decimal(order[1]) / size
 
-                    if levels and levels[-i].price == price:
+                    if levels and levels[-1].price == price:
                         levels[-1].size += size
                     else:
                         levels.append(BookLevel(price=price, size=size))


### PR DESCRIPTION
# fix: IndexError: list index out of range when constructing orderbook.

## Description

When constructing the `Orderbook` offers for the exact same price are meant to be combined into one level. However there is a typo in the logic.

## What was the issue?

Closes https://github.com/RubiconDeFi/rubi-py/issues/84

## What type of change was this 

- [X] fix - fixing bugs and adding small changes (X.X.X+1)
- [ ] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



