### PR TITLE
feat: python-semantic-release version

### DIFF
--- a/rubi/pyproject.toml
+++ b/rubi/pyproject.toml
@@ -20,7 +20,7 @@ py-evm = "0.7.0a4"
 eth-utils = "2.2.0"
 subgrounds = { version = "1.6.0", extras = ["dash"] }
 pyyaml = "6.0.1"
-python-semantic-release = "8.0.4"
+python-semantic-release = "7.34.3"                             # Warning: upgrading to 8.0.0 breaks existing ci/cd gh actions
 black = "23.7.0"
 
 [tool.poetry.group.dev.dependencies]
@@ -41,7 +41,7 @@ test_with_coverage = "scripts:test_with_coverage"
 generate_coverage_report = "scripts:test_coverage_html"
 
 [tool.semantic_release]
-version_toml = ["./pyproject.toml", "tool", "poetry", "version"] # version location
+version_toml = "pyproject.toml:tool.poetry.version"            # version location
 branch = "master"                                              # branch to make releases of
 changelog_file = "./CHANGELOG.md"                              # changelog file
 build_command = "poetry build"                                 # build dists


### PR DESCRIPTION
## Description
downgrades the `python-semantic-release` package so that existing `ci/cd` actions work as expected. if this corrects the action as intended, will result in a minor upgrade to account for work that was previously merged and not published. 



## What type of change was this 

- [ ] none - deployment should be skipped
- [ ] fix - fixing bugs and adding small changes (X.X.X+1)
- [x] feat - introducing a new feature (X.X+1.X)
- [ ] breaking - a breaking API change (X+1.X.X)



